### PR TITLE
Add environment service — lifecycle orchestration

### DIFF
--- a/internal/service/environment.go
+++ b/internal/service/environment.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -80,9 +81,27 @@ func (s *EnvironmentService) Up(build bool) error {
 	return nil
 }
 
+// ErrNoEnvironment is returned when Down or Destroy is called without a prior Up.
+var ErrNoEnvironment = errors.New("no environment found")
+
+// composePath returns the path to the generated compose file and checks it exists.
+func (s *EnvironmentService) composePath() (string, error) {
+	p := filepath.Join(s.projectDir, deckhandDir, "docker-compose.yml")
+	if _, err := os.Stat(p); err != nil {
+		if os.IsNotExist(err) {
+			return "", ErrNoEnvironment
+		}
+		return "", fmt.Errorf("checking compose file: %w", err)
+	}
+	return p, nil
+}
+
 // Down stops containers but leaves the .deckhand/ directory intact.
 func (s *EnvironmentService) Down() error {
-	composePath := filepath.Join(s.projectDir, deckhandDir, "docker-compose.yml")
+	composePath, err := s.composePath()
+	if err != nil {
+		return err
+	}
 	if err := s.compose.Down(s.projectDir, composePath); err != nil {
 		return fmt.Errorf("compose down: %w", err)
 	}
@@ -91,7 +110,13 @@ func (s *EnvironmentService) Down() error {
 
 // Destroy stops containers and removes the .deckhand/ directory.
 func (s *EnvironmentService) Destroy() error {
-	composePath := filepath.Join(s.projectDir, deckhandDir, "docker-compose.yml")
+	composePath, err := s.composePath()
+	if err != nil {
+		if errors.Is(err, ErrNoEnvironment) {
+			return nil // nothing to destroy
+		}
+		return err
+	}
 	if err := s.compose.Destroy(s.projectDir, composePath); err != nil {
 		return fmt.Errorf("compose destroy: %w", err)
 	}

--- a/internal/service/environment_test.go
+++ b/internal/service/environment_test.go
@@ -232,6 +232,39 @@ func TestDestroy_MissingDeckhandDir(t *testing.T) {
 	}
 }
 
+func TestDown_ComposeError(t *testing.T) {
+	svc, _, dir := newTestEnv(t)
+
+	// Create .deckhand/ so the compose file exists.
+	if err := svc.Up(false); err != nil {
+		t.Fatalf("Up() error: %v", err)
+	}
+
+	// Re-create with a failing compose runner.
+	source := newFakeSource()
+	compose := &spyCompose{downErr: errors.New("down failed")}
+	project := domain.Project{Name: "myapp", Template: "base"}
+	svc = service.NewEnvironmentService(source, compose, project, dir)
+
+	err := svc.Down()
+	if err == nil {
+		t.Fatal("expected error when compose down fails")
+	}
+	if !strings.Contains(err.Error(), "down failed") {
+		t.Errorf("error should contain cause, got: %v", err)
+	}
+}
+
+func TestDown_NoEnvironment(t *testing.T) {
+	svc, _, _ := newTestEnv(t)
+
+	// No prior Up — .deckhand/ doesn't exist.
+	err := svc.Down()
+	if !errors.Is(err, service.ErrNoEnvironment) {
+		t.Fatalf("expected ErrNoEnvironment, got: %v", err)
+	}
+}
+
 func TestUp_TemplateRenderingFails(t *testing.T) {
 	dir := t.TempDir()
 	source := &fakeSource{err: errors.New("template broken")}


### PR DESCRIPTION
## Summary
- Adds `EnvironmentService` in `internal/service/environment.go` with `Up(build)`, `Down()`, and `Destroy()` methods that orchestrate template rendering and Docker compose operations
- Defines `ComposeRunner` interface in the service package for dependency inversion against the Docker infra layer
- 9 unit tests covering all acceptance criteria: rendering + file writing, build flag passthrough, file overwriting, DO NOT EDIT header format, down preserving files, destroy cleanup, missing directory handling, and error propagation for both template and compose failures

## Test plan
- [x] `go test ./...` — all tests pass
- [x] `golangci-lint run ./...` — no issues
- [ ] Review that `ComposeRunner` interface matches `docker.Compose` signatures
- [ ] Verify DO NOT EDIT header format matches spec

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)