### PR TITLE
feat: add mount domain types (volume, secret, socket)

### DIFF
--- a/internal/domain/mount.go
+++ b/internal/domain/mount.go
@@ -1,0 +1,46 @@
+package domain
+
+import "fmt"
+
+// VolumeMount represents a named Docker volume.
+type VolumeMount struct {
+	Name    string `yaml:"name"`
+	Target  string `yaml:"target"`
+	Enabled *bool  `yaml:"enabled,omitempty"`
+}
+
+// SecretMount represents a credential injected as an env var, file, or both.
+// The source field holds a raw string — env var references (${VAR}) and file
+// paths (~/.gitconfig) are resolved by the service layer, not here.
+type SecretMount struct {
+	Name     string `yaml:"name"`
+	Source   string `yaml:"source,omitempty"`
+	Target   string `yaml:"target,omitempty"`
+	Env      string `yaml:"env,omitempty"`
+	ReadOnly bool   `yaml:"readonly,omitempty"`
+	Enabled  *bool  `yaml:"enabled,omitempty"`
+}
+
+// Validate checks that a SecretMount has at least one output (env or target).
+func (s SecretMount) Validate() error {
+	if s.Env == "" && s.Target == "" {
+		return fmt.Errorf("secret %q must have at least one of env or target", s.Name)
+	}
+	return nil
+}
+
+// SocketMount represents a Unix socket forwarded from host into the container.
+type SocketMount struct {
+	Name    string `yaml:"name"`
+	Source  string `yaml:"source,omitempty"`
+	Target  string `yaml:"target,omitempty"`
+	Env     string `yaml:"env,omitempty"`
+	Enabled *bool  `yaml:"enabled,omitempty"`
+}
+
+// Mounts groups the three mount primitive slices.
+type Mounts struct {
+	Volumes []VolumeMount `yaml:"volumes,omitempty"`
+	Secrets []SecretMount `yaml:"secrets,omitempty"`
+	Sockets []SocketMount `yaml:"sockets,omitempty"`
+}

--- a/internal/domain/mount_test.go
+++ b/internal/domain/mount_test.go
@@ -1,0 +1,226 @@
+package domain
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestVolumeMount_YAMLRoundTrip(t *testing.T) {
+	input := `
+mounts:
+  volumes:
+    - name: workspace
+      target: /workspace
+`
+	var p Project
+	if err := yaml.Unmarshal([]byte(input), &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(p.Mounts.Volumes) != 1 {
+		t.Fatalf("Volumes length: got %d, want 1", len(p.Mounts.Volumes))
+	}
+	v := p.Mounts.Volumes[0]
+	if v.Name != "workspace" {
+		t.Errorf("Name: got %q, want %q", v.Name, "workspace")
+	}
+	if v.Target != "/workspace" {
+		t.Errorf("Target: got %q, want %q", v.Target, "/workspace")
+	}
+	if v.Enabled != nil {
+		t.Errorf("Enabled: got %v, want nil", v.Enabled)
+	}
+}
+
+func TestSecretMount_YAMLRoundTrip(t *testing.T) {
+	input := `
+mounts:
+  secrets:
+    - name: gh-token
+      source: "${GH_TOKEN}"
+      env: GH_TOKEN
+`
+	var p Project
+	if err := yaml.Unmarshal([]byte(input), &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(p.Mounts.Secrets) != 1 {
+		t.Fatalf("Secrets length: got %d, want 1", len(p.Mounts.Secrets))
+	}
+	s := p.Mounts.Secrets[0]
+	if s.Source != "${GH_TOKEN}" {
+		t.Errorf("Source: got %q, want %q", s.Source, "${GH_TOKEN}")
+	}
+	if s.Env != "GH_TOKEN" {
+		t.Errorf("Env: got %q, want %q", s.Env, "GH_TOKEN")
+	}
+	if s.Target != "" {
+		t.Errorf("Target: got %q, want empty", s.Target)
+	}
+}
+
+func TestSecretMount_EnabledFalse(t *testing.T) {
+	input := `
+mounts:
+  secrets:
+    - name: gh-token
+      enabled: false
+`
+	var p Project
+	if err := yaml.Unmarshal([]byte(input), &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	s := p.Mounts.Secrets[0]
+	if s.Enabled == nil {
+		t.Fatal("Enabled: got nil, want pointer to false")
+	}
+	if *s.Enabled != false {
+		t.Errorf("Enabled: got %v, want false", *s.Enabled)
+	}
+}
+
+func TestSecretMount_Validate_NoOutput(t *testing.T) {
+	s := SecretMount{
+		Name:   "gh-token",
+		Source: "${GH_TOKEN}",
+	}
+	if err := s.Validate(); err == nil {
+		t.Error("expected validation error for secret with no env and no target")
+	}
+}
+
+func TestSecretMount_Validate_WithEnv(t *testing.T) {
+	s := SecretMount{
+		Name:   "gh-token",
+		Source: "${GH_TOKEN}",
+		Env:    "GH_TOKEN",
+	}
+	if err := s.Validate(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSecretMount_Validate_WithTarget(t *testing.T) {
+	s := SecretMount{
+		Name:   "gitconfig",
+		Source: "~/.gitconfig",
+		Target: "/home/dev/.gitconfig",
+	}
+	if err := s.Validate(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestTemplateMeta_MountsYAML(t *testing.T) {
+	input := `
+name: go
+description: Go dev environment
+variables:
+  go_version:
+    default: "1.22"
+    description: Go version
+mounts:
+  volumes:
+    - name: workspace
+      target: /workspace
+    - name: go-mod-cache
+      target: /home/dev/go/pkg/mod
+`
+	var m TemplateMeta
+	if err := yaml.Unmarshal([]byte(input), &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(m.Mounts.Volumes) != 2 {
+		t.Fatalf("Volumes length: got %d, want 2", len(m.Mounts.Volumes))
+	}
+	if m.Mounts.Volumes[0].Name != "workspace" {
+		t.Errorf("Volumes[0].Name: got %q, want %q", m.Mounts.Volumes[0].Name, "workspace")
+	}
+}
+
+func TestMounts_OmitEmpty(t *testing.T) {
+	p := Project{
+		Name:     "test",
+		Template: "base",
+	}
+	data, err := yaml.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if contains(string(data), "mounts") {
+		t.Errorf("marshaled YAML should not contain 'mounts' when empty\nGot:\n%s", data)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+func TestFullProjectWithMounts_YAMLRoundTrip(t *testing.T) {
+	input := `
+project: my-api
+template: go
+mounts:
+  volumes:
+    - name: workspace
+      target: /workspace
+  secrets:
+    - name: gh-token
+      source: "${GH_TOKEN}"
+      env: GH_TOKEN
+    - name: gitconfig
+      source: ~/.gitconfig
+      target: /home/dev/.gitconfig
+      readonly: true
+  sockets:
+    - name: ssh-agent
+      source: "${SSH_AUTH_SOCK}"
+      target: /run/ssh-agent.sock
+      env: SSH_AUTH_SOCK
+`
+	var p Project
+	if err := yaml.Unmarshal([]byte(input), &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(p.Mounts.Volumes) != 1 {
+		t.Fatalf("Volumes: got %d, want 1", len(p.Mounts.Volumes))
+	}
+	if len(p.Mounts.Secrets) != 2 {
+		t.Fatalf("Secrets: got %d, want 2", len(p.Mounts.Secrets))
+	}
+	if len(p.Mounts.Sockets) != 1 {
+		t.Fatalf("Sockets: got %d, want 1", len(p.Mounts.Sockets))
+	}
+
+	// Verify secret fields
+	gitconfig := p.Mounts.Secrets[1]
+	if gitconfig.ReadOnly != true {
+		t.Errorf("gitconfig.ReadOnly: got %v, want true", gitconfig.ReadOnly)
+	}
+	if gitconfig.Target != "/home/dev/.gitconfig" {
+		t.Errorf("gitconfig.Target: got %q, want %q", gitconfig.Target, "/home/dev/.gitconfig")
+	}
+
+	// Verify socket fields
+	ssh := p.Mounts.Sockets[0]
+	if ssh.Source != "${SSH_AUTH_SOCK}" {
+		t.Errorf("ssh.Source: got %q, want %q", ssh.Source, "${SSH_AUTH_SOCK}")
+	}
+	if ssh.Env != "SSH_AUTH_SOCK" {
+		t.Errorf("ssh.Env: got %q, want %q", ssh.Env, "SSH_AUTH_SOCK")
+	}
+}

--- a/internal/domain/project.go
+++ b/internal/domain/project.go
@@ -8,6 +8,7 @@ type Project struct {
 	Ports     []PortMapping     `yaml:"ports"`
 	Env       map[string]string `yaml:"env"`
 	Variables map[string]string `yaml:"variables,omitempty"`
+	Mounts    Mounts            `yaml:"mounts,omitempty"`
 }
 
 // TemplateVariable describes a single configurable variable in a template.
@@ -21,6 +22,7 @@ type TemplateMeta struct {
 	Name        string                      `yaml:"name"`
 	Description string                      `yaml:"description"`
 	Variables   map[string]TemplateVariable `yaml:"variables"`
+	Mounts      Mounts                      `yaml:"mounts,omitempty"`
 }
 
 // TemplateInfo describes a discovered template for listing purposes.


### PR DESCRIPTION
## Summary
- Add `VolumeMount`, `SecretMount`, `SocketMount`, and `Mounts` grouping struct to `internal/domain/mount.go`
- Add `Mounts` field to `Project` and `TemplateMeta` structs with `omitempty` tags
- `SecretMount.Validate()` ensures at least one of `env` or `target` is set
- `enabled` uses `*bool` for tristate semantics (nil/true/false) needed by merge logic in #43

Closes #41

## Test plan
- [x] YAML round-trip for volume mount (enabled is nil when omitted)
- [x] YAML round-trip for secret mount (source, env, empty target)
- [x] `enabled: false` deserializes to pointer-to-false
- [x] Secret validation rejects missing env+target
- [x] Secret validation accepts env-only and target-only
- [x] TemplateMeta mounts deserialization
- [x] Mounts omitempty — existing configs unaffected
- [x] Full project with all three mount types
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Projects now support configurable volume, secret, and socket mount definitions with optional enable/disable toggles.
  * Mount configuration validation ensures required fields are properly configured before use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->