### PR TITLE
feat: mount merging and env var resolution #43

### DIFF
--- a/internal/service/mount.go
+++ b/internal/service/mount.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -141,7 +142,10 @@ func resolveFilePath(source string) (string, error) {
 	expanded := expandTilde(source)
 
 	if _, err := os.Stat(expanded); err != nil {
-		return "", fmt.Errorf("source file does not exist: %s", expanded)
+		if errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("source file does not exist: %s", expanded)
+		}
+		return "", fmt.Errorf("cannot access source file %s: %w", expanded, err)
 	}
 
 	return expanded, nil

--- a/internal/service/mount_test.go
+++ b/internal/service/mount_test.go
@@ -8,6 +8,12 @@ import (
 	"github.com/TomasGrbalik/deckhand/internal/domain"
 )
 
+func setTestHome(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+}
+
 func TestMergeMounts_BasicThreeWayMerge(t *testing.T) {
 	t.Setenv("GH_TOKEN", "ghp_abc123")
 	t.Setenv("API_KEY", "key_xyz")
@@ -152,8 +158,8 @@ func TestMergeMounts_TildeExpansion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Override HOME so ~ expands to our temp dir.
-	t.Setenv("HOME", fakeHome)
+	// Override home-related env vars so ~ expansion is deterministic.
+	setTestHome(t, fakeHome)
 
 	input := domain.Mounts{
 		Secrets: []domain.SecretMount{
@@ -177,7 +183,7 @@ func TestMergeMounts_TildeExpansion(t *testing.T) {
 
 func TestMergeMounts_MissingSourceFile(t *testing.T) {
 	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	setTestHome(t, tmpDir)
 
 	input := domain.Mounts{
 		Secrets: []domain.SecretMount{


### PR DESCRIPTION
## Summary
- Add `MergeMounts()` in `internal/service/mount.go` — three-way merge of mounts (template defaults → global config → project config) by name, with higher-precedence sources replacing lower ones
- Resolve `${VAR}` env var references and `~/` tilde paths in source fields at merge time; skip unresolvable mounts with warnings
- Support `enabled: false` to remove inherited mounts from the merged result
- 12 unit tests covering all 8 acceptance scenarios from #43

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [ ] CodeRabbit review

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Merge mount configurations from template, global, and project layers with name-based deduplication; project entries override earlier layers. Disabled mounts are omitted. Secret and socket sources support environment-variable expansion and home-directory (~) resolution; invalid or unreadable sources are skipped and emit warnings.

* **Tests**
  * Added comprehensive tests covering three-way merges, tilde and env-var expansion, disabled mounts, missing sources, and warning emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->