### PR TITLE
feat: wire DECKHAND_PROJECT and DECKHAND_TEMPLATE env var overrides

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,15 @@ func Load(path string) (*domain.Project, error) {
 		return nil, fmt.Errorf("config version %d is not supported — please upgrade deckhand", proj.Version)
 	}
 
+	// Env var overrides: DECKHAND_PROJECT and DECKHAND_TEMPLATE take
+	// precedence over file values (but flags still win at the CLI layer).
+	if v := os.Getenv("DECKHAND_PROJECT"); v != "" {
+		proj.Name = v
+	}
+	if v := os.Getenv("DECKHAND_TEMPLATE"); v != "" {
+		proj.Template = v
+	}
+
 	return &proj, nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -349,6 +349,112 @@ func TestLoad_EmptyFile(t *testing.T) {
 	}
 }
 
+func TestLoad_EnvVarOverrideProject(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".deckhand.yaml")
+
+	content := `project: myapp
+template: base
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("DECKHAND_PROJECT", "override-name")
+
+	proj, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load() returned error: %v", err)
+	}
+
+	if proj.Name != "override-name" {
+		t.Errorf("Name = %q, want %q", proj.Name, "override-name")
+	}
+	if proj.Template != "base" {
+		t.Errorf("Template = %q, want %q (should be unchanged)", proj.Template, "base")
+	}
+}
+
+func TestLoad_EnvVarOverrideTemplate(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".deckhand.yaml")
+
+	content := `project: myapp
+template: go
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("DECKHAND_TEMPLATE", "rust")
+
+	proj, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load() returned error: %v", err)
+	}
+
+	if proj.Template != "rust" {
+		t.Errorf("Template = %q, want %q", proj.Template, "rust")
+	}
+	if proj.Name != "myapp" {
+		t.Errorf("Name = %q, want %q (should be unchanged)", proj.Name, "myapp")
+	}
+}
+
+func TestLoad_EnvVarOverrideBoth(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".deckhand.yaml")
+
+	content := `project: myapp
+template: base
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("DECKHAND_PROJECT", "ci-build")
+	t.Setenv("DECKHAND_TEMPLATE", "node")
+
+	proj, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load() returned error: %v", err)
+	}
+
+	if proj.Name != "ci-build" {
+		t.Errorf("Name = %q, want %q", proj.Name, "ci-build")
+	}
+	if proj.Template != "node" {
+		t.Errorf("Template = %q, want %q", proj.Template, "node")
+	}
+}
+
+func TestLoad_EnvVarEmptyDoesNotOverride(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".deckhand.yaml")
+
+	content := `project: myapp
+template: base
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("DECKHAND_PROJECT", "")
+	t.Setenv("DECKHAND_TEMPLATE", "")
+
+	proj, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load() returned error: %v", err)
+	}
+
+	if proj.Name != "myapp" {
+		t.Errorf("Name = %q, want %q (empty env var should not override)", proj.Name, "myapp")
+	}
+	if proj.Template != "base" {
+		t.Errorf("Template = %q, want %q (empty env var should not override)", proj.Template, "base")
+	}
+}
+
 func TestLoadGlobal_CompleteConfig(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")


### PR DESCRIPTION
## Summary
- Add `DECKHAND_PROJECT` and `DECKHAND_TEMPLATE` env var overrides in `config.Load()`, applied after file unmarshal so the precedence chain is: flags > env vars > project config > global config
- Only non-empty env var values override (empty string = not set)
- Uses `os.Getenv` directly — simpler than koanf env provider for two scalars

Closes #54

## Test plan
- [x] `TestLoad_EnvVarOverrideProject` — only project name overridden
- [x] `TestLoad_EnvVarOverrideTemplate` — only template overridden
- [x] `TestLoad_EnvVarOverrideBoth` — both set simultaneously
- [x] `TestLoad_EnvVarEmptyDoesNotOverride` — empty string leaves file values intact
- [x] All existing tests still pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)