### PR TITLE
feat: companion service domain types and registry

### DIFF
--- a/internal/domain/companion.go
+++ b/internal/domain/companion.go
@@ -1,0 +1,27 @@
+package domain
+
+// CompanionService describes a companion service available in the registry.
+type CompanionService struct {
+	Name        string            `yaml:"name"`
+	Description string            `yaml:"description"`
+	Image       string            `yaml:"image"`
+	Ports       []int             `yaml:"ports"`
+	Environment map[string]string `yaml:"environment"`
+	HealthCheck HealthCheck       `yaml:"healthcheck"`
+	Volumes     []string          `yaml:"volumes"`
+}
+
+// HealthCheck defines how to verify a companion service is ready.
+type HealthCheck struct {
+	Test     string `yaml:"test"`
+	Interval string `yaml:"interval"`
+	Timeout  string `yaml:"timeout"`
+	Retries  int    `yaml:"retries"`
+}
+
+// ServiceConfig represents a companion service selection in the project config.
+type ServiceConfig struct {
+	Name    string `yaml:"name"`
+	Version string `yaml:"version,omitempty"`
+	Enabled bool   `yaml:"enabled"`
+}

--- a/internal/domain/companion_test.go
+++ b/internal/domain/companion_test.go
@@ -1,0 +1,140 @@
+package domain
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestServiceConfigYAMLRoundTrip(t *testing.T) {
+	original := []ServiceConfig{
+		{Name: "postgres", Enabled: true},
+		{Name: "redis", Version: "7", Enabled: true},
+	}
+
+	data, err := yaml.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded []ServiceConfig
+	if err := yaml.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(decoded) != 2 {
+		t.Fatalf("length: got %d, want 2", len(decoded))
+	}
+	if decoded[0].Name != "postgres" {
+		t.Errorf("decoded[0].Name: got %q, want %q", decoded[0].Name, "postgres")
+	}
+	if decoded[1].Version != "7" {
+		t.Errorf("decoded[1].Version: got %q, want %q", decoded[1].Version, "7")
+	}
+}
+
+func TestServiceConfigVersionOmitEmpty(t *testing.T) {
+	cfg := ServiceConfig{Name: "postgres", Enabled: true}
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "version") {
+		t.Errorf("marshaled YAML should not contain 'version' when empty\nGot:\n%s", data)
+	}
+}
+
+func TestProjectServicesYAMLRoundTrip(t *testing.T) {
+	original := Project{
+		Name:     "my-api",
+		Template: "go",
+		Services: []ServiceConfig{
+			{Name: "postgres", Enabled: true},
+			{Name: "redis", Enabled: true},
+		},
+	}
+
+	data, err := yaml.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if !strings.Contains(string(data), "services:") {
+		t.Errorf("marshaled YAML should contain 'services:'\nGot:\n%s", data)
+	}
+
+	var decoded Project
+	if err := yaml.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(decoded.Services) != 2 {
+		t.Fatalf("Services length: got %d, want 2", len(decoded.Services))
+	}
+	if decoded.Services[0].Name != "postgres" {
+		t.Errorf("Services[0].Name: got %q, want %q", decoded.Services[0].Name, "postgres")
+	}
+}
+
+func TestProjectServicesOmitEmpty(t *testing.T) {
+	original := Project{
+		Name:     "my-api",
+		Template: "base",
+	}
+
+	data, err := yaml.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if strings.Contains(string(data), "services") {
+		t.Errorf("marshaled YAML should not contain 'services' when empty\nGot:\n%s", data)
+	}
+}
+
+func TestCompanionServiceYAMLRoundTrip(t *testing.T) {
+	original := CompanionService{
+		Name:        "postgres",
+		Description: "PostgreSQL relational database",
+		Image:       "postgres:16-alpine",
+		Ports:       []int{5432},
+		Environment: map[string]string{"POSTGRES_USER": "dev"},
+		HealthCheck: HealthCheck{
+			Test:     "pg_isready -U dev",
+			Interval: "5s",
+			Timeout:  "3s",
+			Retries:  5,
+		},
+		Volumes: []string{"postgres-data:/var/lib/postgresql/data"},
+	}
+
+	data, err := yaml.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded CompanionService
+	if err := yaml.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded.Name != original.Name {
+		t.Errorf("Name: got %q, want %q", decoded.Name, original.Name)
+	}
+	if decoded.Image != original.Image {
+		t.Errorf("Image: got %q, want %q", decoded.Image, original.Image)
+	}
+	if len(decoded.Ports) != 1 || decoded.Ports[0] != 5432 {
+		t.Errorf("Ports: got %v, want [5432]", decoded.Ports)
+	}
+	if decoded.HealthCheck.Test != original.HealthCheck.Test {
+		t.Errorf("HealthCheck.Test: got %q, want %q", decoded.HealthCheck.Test, original.HealthCheck.Test)
+	}
+	if decoded.HealthCheck.Retries != 5 {
+		t.Errorf("HealthCheck.Retries: got %d, want 5", decoded.HealthCheck.Retries)
+	}
+	if len(decoded.Volumes) != 1 {
+		t.Errorf("Volumes length: got %d, want 1", len(decoded.Volumes))
+	}
+}

--- a/internal/domain/project.go
+++ b/internal/domain/project.go
@@ -10,6 +10,7 @@ type Project struct {
 	Env       map[string]string `yaml:"env"`
 	Variables map[string]string `yaml:"variables,omitempty"`
 	Mounts    Mounts            `yaml:"mounts,omitempty"`
+	Services  []ServiceConfig   `yaml:"services,omitempty"`
 }
 
 // TemplateVariable describes a single configurable variable in a template.

--- a/internal/service/companion.go
+++ b/internal/service/companion.go
@@ -1,0 +1,76 @@
+package service
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/TomasGrbalik/deckhand/internal/domain"
+)
+
+// CompanionRegistry provides access to the hardcoded set of companion services.
+type CompanionRegistry struct {
+	services map[string]domain.CompanionService
+}
+
+// NewCompanionRegistry creates a registry pre-loaded with the built-in
+// companion service definitions (postgres, redis).
+func NewCompanionRegistry() *CompanionRegistry {
+	return &CompanionRegistry{
+		services: map[string]domain.CompanionService{
+			"postgres": {
+				Name:        "postgres",
+				Description: "PostgreSQL relational database",
+				Image:       "postgres:16-alpine",
+				Ports:       []int{5432},
+				Environment: map[string]string{
+					"POSTGRES_USER":     "dev",
+					"POSTGRES_PASSWORD": "dev",
+					"POSTGRES_DB":       "devdb",
+				},
+				HealthCheck: domain.HealthCheck{
+					Test:     "pg_isready -U dev",
+					Interval: "5s",
+					Timeout:  "3s",
+					Retries:  5,
+				},
+				Volumes: []string{"postgres-data:/var/lib/postgresql/data"},
+			},
+			"redis": {
+				Name:        "redis",
+				Description: "Redis in-memory data store",
+				Image:       "redis:7-alpine",
+				Ports:       []int{6379},
+				Environment: map[string]string{},
+				HealthCheck: domain.HealthCheck{
+					Test:     "redis-cli ping",
+					Interval: "5s",
+					Timeout:  "3s",
+					Retries:  5,
+				},
+				Volumes: []string{"redis-data:/data"},
+			},
+		},
+	}
+}
+
+// ListAvailable returns all registered companion services, sorted by name.
+func (r *CompanionRegistry) ListAvailable() []domain.CompanionService {
+	result := make([]domain.CompanionService, 0, len(r.services))
+	for _, svc := range r.services {
+		result = append(result, svc)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+	return result
+}
+
+// Resolve looks up a companion service by name. The version parameter is
+// accepted for future use but currently ignored.
+func (r *CompanionRegistry) Resolve(name, _version string) (domain.CompanionService, error) {
+	svc, ok := r.services[name]
+	if !ok {
+		return domain.CompanionService{}, fmt.Errorf("unknown companion service: %q", name)
+	}
+	return svc, nil
+}

--- a/internal/service/companion_test.go
+++ b/internal/service/companion_test.go
@@ -1,0 +1,97 @@
+package service_test
+
+import (
+	"testing"
+
+	"github.com/TomasGrbalik/deckhand/internal/service"
+)
+
+func TestCompanionRegistry_ListAvailable(t *testing.T) {
+	reg := service.NewCompanionRegistry()
+	services := reg.ListAvailable()
+
+	if len(services) != 2 {
+		t.Fatalf("expected 2 services, got %d", len(services))
+	}
+
+	// Results should be sorted by name.
+	if services[0].Name != "postgres" {
+		t.Errorf("services[0].Name: got %q, want %q", services[0].Name, "postgres")
+	}
+	if services[1].Name != "redis" {
+		t.Errorf("services[1].Name: got %q, want %q", services[1].Name, "redis")
+	}
+}
+
+func TestCompanionRegistry_ResolvePostgres(t *testing.T) {
+	reg := service.NewCompanionRegistry()
+	svc, err := reg.Resolve("postgres", "")
+	if err != nil {
+		t.Fatalf("Resolve(postgres) error: %v", err)
+	}
+
+	if svc.Image != "postgres:16-alpine" {
+		t.Errorf("Image: got %q, want %q", svc.Image, "postgres:16-alpine")
+	}
+	if len(svc.Ports) != 1 || svc.Ports[0] != 5432 {
+		t.Errorf("Ports: got %v, want [5432]", svc.Ports)
+	}
+	if svc.HealthCheck.Test != "pg_isready -U dev" {
+		t.Errorf("HealthCheck.Test: got %q, want %q", svc.HealthCheck.Test, "pg_isready -U dev")
+	}
+	if svc.Environment["POSTGRES_USER"] != "dev" {
+		t.Errorf("Environment[POSTGRES_USER]: got %q, want %q", svc.Environment["POSTGRES_USER"], "dev")
+	}
+	if svc.Environment["POSTGRES_DB"] != "devdb" {
+		t.Errorf("Environment[POSTGRES_DB]: got %q, want %q", svc.Environment["POSTGRES_DB"], "devdb")
+	}
+}
+
+func TestCompanionRegistry_ResolveRedis(t *testing.T) {
+	reg := service.NewCompanionRegistry()
+	svc, err := reg.Resolve("redis", "")
+	if err != nil {
+		t.Fatalf("Resolve(redis) error: %v", err)
+	}
+
+	if svc.Image != "redis:7-alpine" {
+		t.Errorf("Image: got %q, want %q", svc.Image, "redis:7-alpine")
+	}
+	if len(svc.Ports) != 1 || svc.Ports[0] != 6379 {
+		t.Errorf("Ports: got %v, want [6379]", svc.Ports)
+	}
+	if svc.HealthCheck.Test != "redis-cli ping" {
+		t.Errorf("HealthCheck.Test: got %q, want %q", svc.HealthCheck.Test, "redis-cli ping")
+	}
+}
+
+func TestCompanionRegistry_ResolveUnknown(t *testing.T) {
+	reg := service.NewCompanionRegistry()
+	_, err := reg.Resolve("mysql", "")
+	if err == nil {
+		t.Fatal("expected error for unknown service, got nil")
+	}
+}
+
+func TestCompanionRegistry_ListAvailableFields(t *testing.T) {
+	reg := service.NewCompanionRegistry()
+	services := reg.ListAvailable()
+
+	for _, svc := range services {
+		if svc.Name == "" {
+			t.Error("service Name should not be empty")
+		}
+		if svc.Description == "" {
+			t.Errorf("service %q Description should not be empty", svc.Name)
+		}
+		if svc.Image == "" {
+			t.Errorf("service %q Image should not be empty", svc.Name)
+		}
+		if len(svc.Ports) == 0 {
+			t.Errorf("service %q should have at least one port", svc.Name)
+		}
+		if svc.HealthCheck.Test == "" {
+			t.Errorf("service %q HealthCheck.Test should not be empty", svc.Name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add `CompanionService`, `HealthCheck`, and `ServiceConfig` domain types in `internal/domain/companion.go`
- Add `Services []ServiceConfig` field to `Project` struct for `.deckhand.yaml` config support
- Add `CompanionRegistry` in `internal/service/companion.go` with hardcoded postgres and redis definitions, `ListAvailable()` and `Resolve()` methods
- Full unit test coverage for domain YAML serialization, registry list/resolve/unknown

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `golangci-lint run ./...` clean
- [ ] Wait for CI checks
- [ ] CodeRabbit review

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for companion services with built-in PostgreSQL and Redis options, including configurable health checks, port exposure, environment variables, and volume management
  * Projects can now include and manage service configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->