### PR TITLE
feat: companion service selection in init flow

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -69,6 +69,15 @@ func newInitCmd() *cobra.Command {
 				}
 			}
 
+			// --- Companion service selection ---
+			var selectedServices []string
+			if !templateFlagSet {
+				selectedServices, err = pickCompanions(initSvc)
+				if err != nil {
+					return err
+				}
+			}
+
 			// --- Project name ---
 			projectName := projectFlag
 			if !cmd.Flags().Changed("project") {
@@ -80,7 +89,7 @@ func newInitCmd() *cobra.Command {
 			}
 
 			// Build and save.
-			proj := initSvc.BuildProject(projectName, templateName, variables, meta)
+			proj := initSvc.BuildProject(projectName, templateName, variables, meta, selectedServices)
 			if err := config.Save(cfgPath, proj); err != nil {
 				return err
 			}
@@ -105,6 +114,7 @@ func newInitCmd() *cobra.Command {
 // to embedded, so user templates can override builtins for metadata loading.
 func newInitService() *service.InitService {
 	embedded := &template.EmbeddedSource{}
+	companions := service.NewCompanionRegistry()
 
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -112,6 +122,7 @@ func newInitService() *service.InitService {
 		return service.NewInitService(
 			service.NewTemplateRegistry(embedded),
 			embedded,
+			companions,
 		)
 	}
 	userDir := filepath.Join(home, ".config", "deckhand", "templates")
@@ -119,7 +130,7 @@ func newInitService() *service.InitService {
 	registry := service.NewTemplateRegistry(embedded, fs)
 	source := &compositeSource{sources: []service.TemplateSource{fs, embedded}}
 
-	return service.NewInitService(registry, source)
+	return service.NewInitService(registry, source, companions)
 }
 
 // pickTemplate shows an interactive template picker. If only one template
@@ -206,6 +217,36 @@ func editVariables(svc *service.InitService, meta *domain.TemplateMeta, defaults
 	}
 
 	return result, nil
+}
+
+// pickCompanions shows an interactive multi-select for companion services.
+// Returns the selected service names, or nil if none are available.
+func pickCompanions(svc *service.InitService) ([]string, error) {
+	companions := svc.ListCompanions()
+	if len(companions) == 0 {
+		return nil, nil
+	}
+
+	options := make([]huh.Option[string], len(companions))
+	for i, c := range companions {
+		label := fmt.Sprintf("%s — %s", c.Name, c.Description)
+		options[i] = huh.NewOption(label, c.Name)
+	}
+
+	var selected []string
+	err := huh.NewMultiSelect[string]().
+		Title("Select companion services (optional)").
+		Options(options...).
+		Value(&selected).
+		Run()
+	if err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return nil, errCanceled
+		}
+		return nil, fmt.Errorf("companion selection: %w", err)
+	}
+
+	return selected, nil
 }
 
 // promptProjectName asks for the project name with a default.

--- a/internal/service/init.go
+++ b/internal/service/init.go
@@ -7,17 +7,25 @@ import (
 	"github.com/TomasGrbalik/deckhand/internal/domain"
 )
 
+// CompanionLister returns the available companion services for selection.
+// The CompanionRegistry satisfies this interface.
+type CompanionLister interface {
+	ListAvailable() []domain.CompanionService
+}
+
 // InitService handles the business logic for initializing a new project.
 // It discovers templates, validates selections, and builds project configs.
 // No UI/CLI imports — form interaction stays in the CLI layer.
 type InitService struct {
-	lister TemplateLister
-	source TemplateSource
+	lister     TemplateLister
+	source     TemplateSource
+	companions CompanionLister
 }
 
 // NewInitService creates an InitService with the given template lister and source.
-func NewInitService(lister TemplateLister, source TemplateSource) *InitService {
-	return &InitService{lister: lister, source: source}
+// An optional CompanionLister can be provided for companion service selection.
+func NewInitService(lister TemplateLister, source TemplateSource, companions CompanionLister) *InitService {
+	return &InitService{lister: lister, source: source, companions: companions}
 }
 
 // ListTemplates returns all available templates.
@@ -73,9 +81,19 @@ func (s *InitService) SortedVariableNames(meta *domain.TemplateMeta) []string {
 	return names
 }
 
+// ListCompanions returns the available companion services for selection.
+// Returns nil if no CompanionLister was provided.
+func (s *InitService) ListCompanions() []domain.CompanionService {
+	if s.companions == nil {
+		return nil
+	}
+	return s.companions.ListAvailable()
+}
+
 // BuildProject creates a domain.Project from the given inputs.
 // Variables are only included if they differ from template defaults.
-func (s *InitService) BuildProject(projectName, templateName string, variables map[string]string, meta *domain.TemplateMeta) *domain.Project {
+// Selected service names produce ServiceConfig entries with Enabled=true.
+func (s *InitService) BuildProject(projectName, templateName string, variables map[string]string, meta *domain.TemplateMeta, selectedServices []string) *domain.Project {
 	// Only store variables that differ from defaults.
 	overrides := make(map[string]string)
 	for k, v := range variables {
@@ -91,6 +109,17 @@ func (s *InitService) BuildProject(projectName, templateName string, variables m
 	}
 	if len(overrides) > 0 {
 		proj.Variables = overrides
+	}
+
+	if len(selectedServices) > 0 {
+		services := make([]domain.ServiceConfig, len(selectedServices))
+		for i, name := range selectedServices {
+			services[i] = domain.ServiceConfig{
+				Name:    name,
+				Enabled: true,
+			}
+		}
+		proj.Services = services
 	}
 
 	return proj

--- a/internal/service/init_test.go
+++ b/internal/service/init_test.go
@@ -9,7 +9,7 @@ import (
 
 func newInitService(templates []domain.TemplateInfo, source *fakeSource) *service.InitService {
 	lister := &fakeTemplateLister{templates: templates}
-	return service.NewInitService(lister, source)
+	return service.NewInitService(lister, source, nil)
 }
 
 func TestInitService_ListTemplates(t *testing.T) {
@@ -140,7 +140,7 @@ func TestInitService_BuildProject_WithOverrides(t *testing.T) {
 		"debug":          "false", // same as default
 	}
 
-	proj := svc.BuildProject("my-api", "python", variables, meta)
+	proj := svc.BuildProject("my-api", "python", variables, meta, nil)
 
 	if proj.Name != "my-api" {
 		t.Errorf("Name = %q, want %q", proj.Name, "my-api")
@@ -170,7 +170,7 @@ func TestInitService_BuildProject_AllDefaults(t *testing.T) {
 		"python_version": "3.12", // same as default
 	}
 
-	proj := svc.BuildProject("my-api", "python", variables, meta)
+	proj := svc.BuildProject("my-api", "python", variables, meta, nil)
 
 	// No overrides → Variables should be nil (omitempty in YAML).
 	if proj.Variables != nil {
@@ -184,7 +184,7 @@ func TestInitService_BuildProject_SetsVersion(t *testing.T) {
 		Variables: map[string]domain.TemplateVariable{},
 	}
 
-	proj := svc.BuildProject("my-app", "base", map[string]string{}, meta)
+	proj := svc.BuildProject("my-app", "base", map[string]string{}, meta, nil)
 
 	if proj.Version != 1 {
 		t.Errorf("Version = %d, want 1", proj.Version)
@@ -197,7 +197,7 @@ func TestInitService_BuildProject_NoVariables(t *testing.T) {
 		Variables: map[string]domain.TemplateVariable{},
 	}
 
-	proj := svc.BuildProject("my-app", "base", map[string]string{}, meta)
+	proj := svc.BuildProject("my-app", "base", map[string]string{}, meta, nil)
 
 	if proj.Name != "my-app" {
 		t.Errorf("Name = %q, want %q", proj.Name, "my-app")
@@ -207,6 +207,97 @@ func TestInitService_BuildProject_NoVariables(t *testing.T) {
 	}
 	if proj.Variables != nil {
 		t.Errorf("expected nil Variables for template with no variables, got %v", proj.Variables)
+	}
+}
+
+// fakeCompanionLister implements service.CompanionLister for testing.
+type fakeCompanionLister struct {
+	services []domain.CompanionService
+}
+
+func (f *fakeCompanionLister) ListAvailable() []domain.CompanionService {
+	return f.services
+}
+
+func newInitServiceWithCompanions(companions *fakeCompanionLister) *service.InitService {
+	return service.NewInitService(&fakeTemplateLister{}, newFakeSource(), companions)
+}
+
+func TestInitService_ListCompanions(t *testing.T) {
+	companions := &fakeCompanionLister{
+		services: []domain.CompanionService{
+			{Name: "postgres", Description: "PostgreSQL"},
+			{Name: "redis", Description: "Redis"},
+		},
+	}
+	svc := newInitServiceWithCompanions(companions)
+
+	result := svc.ListCompanions()
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 companions, got %d", len(result))
+	}
+	if result[0].Name != "postgres" {
+		t.Errorf("first companion = %q, want %q", result[0].Name, "postgres")
+	}
+	if result[1].Name != "redis" {
+		t.Errorf("second companion = %q, want %q", result[1].Name, "redis")
+	}
+}
+
+func TestInitService_ListCompanions_NilLister(t *testing.T) {
+	svc := service.NewInitService(&fakeTemplateLister{}, newFakeSource(), nil)
+
+	result := svc.ListCompanions()
+
+	if result != nil {
+		t.Errorf("expected nil when no companion lister, got %v", result)
+	}
+}
+
+func TestInitService_BuildProject_WithServices(t *testing.T) {
+	svc := newInitService(nil, newFakeSource())
+	meta := &domain.TemplateMeta{
+		Variables: map[string]domain.TemplateVariable{},
+	}
+
+	proj := svc.BuildProject("my-app", "base", map[string]string{}, meta, []string{"postgres", "redis"})
+
+	if len(proj.Services) != 2 {
+		t.Fatalf("expected 2 services, got %d", len(proj.Services))
+	}
+	if proj.Services[0].Name != "postgres" || !proj.Services[0].Enabled {
+		t.Errorf("services[0] = %+v, want postgres enabled", proj.Services[0])
+	}
+	if proj.Services[1].Name != "redis" || !proj.Services[1].Enabled {
+		t.Errorf("services[1] = %+v, want redis enabled", proj.Services[1])
+	}
+}
+
+func TestInitService_BuildProject_NoServices(t *testing.T) {
+	svc := newInitService(nil, newFakeSource())
+	meta := &domain.TemplateMeta{
+		Variables: map[string]domain.TemplateVariable{},
+	}
+
+	proj := svc.BuildProject("my-app", "base", map[string]string{}, meta, nil)
+
+	if proj.Services != nil {
+		t.Errorf("expected nil Services when none selected, got %v", proj.Services)
+	}
+}
+
+func TestInitService_BuildProject_EmptyServices(t *testing.T) {
+	svc := newInitService(nil, newFakeSource())
+	meta := &domain.TemplateMeta{
+		Variables: map[string]domain.TemplateVariable{},
+	}
+
+	proj := svc.BuildProject("my-app", "base", map[string]string{}, meta, []string{})
+
+	// Empty slice should behave like nil — no services key in YAML.
+	if proj.Services != nil {
+		t.Errorf("expected nil Services when empty slice passed, got %v", proj.Services)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds interactive multi-select prompt for companion services (postgres, redis) during `deckhand init`
- Selected services saved to `.deckhand.yaml` as `ServiceConfig` entries with `enabled: true`
- Non-interactive mode (`--template` flag) skips the prompt entirely
- Ctrl+C exits cleanly via existing `errCanceled` pattern

Closes #58

## Test plan
- [x] `TestInitService_ListCompanions` — returns registry contents
- [x] `TestInitService_ListCompanions_NilLister` — nil when no lister
- [x] `TestInitService_BuildProject_WithServices` — produces correct ServiceConfig entries
- [x] `TestInitService_BuildProject_NoServices` — nil when none selected
- [x] `TestInitService_BuildProject_EmptyServices` — empty slice treated as nil (omitempty)
- [ ] Manual: run `deckhand init`, verify multi-select appears after variables
- [ ] Manual: run `deckhand init --template base`, verify no companion prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interactive companion service selection during project initialization when no template flag is provided
  * Selected companion services are automatically enabled in the project configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->