### PR TITLE
feat: enable shell completions (bash, zsh, fish)

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -252,6 +252,27 @@ func TestConnectAcceptsValidHost(t *testing.T) {
 	}
 }
 
+func TestCompletionCommand(t *testing.T) {
+	shells := []string{"bash", "zsh", "fish"}
+
+	for _, shell := range shells {
+		t.Run(shell, func(t *testing.T) {
+			root := newRootCmd()
+			buf := new(bytes.Buffer)
+			root.SetOut(buf)
+			root.SetArgs([]string{"completion", shell})
+
+			if err := root.Execute(); err != nil {
+				t.Fatalf("completion %s: %v", shell, err)
+			}
+
+			if buf.Len() == 0 {
+				t.Fatalf("expected completion output for %s, got empty", shell)
+			}
+		})
+	}
+}
+
 func TestVersionFlag(t *testing.T) {
 	root := newRootCmd()
 	buf := new(bytes.Buffer)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -21,7 +21,6 @@ func newRootCmd() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose output")
-	cmd.CompletionOptions.DisableDefaultCmd = true
 
 	cmd.AddCommand(
 		newInitCmd(),


### PR DESCRIPTION
## Summary
- Remove `CompletionOptions.DisableDefaultCmd = true` from root command to expose Cobra's built-in `completion` subcommand
- Users can now run `deckhand completion bash/zsh/fish` to generate shell completion scripts
- Add smoke test verifying all three shells produce non-empty output

Closes #55

## Test plan
- [x] `go test ./...` passes
- [ ] `deckhand completion bash` prints a valid bash completion script
- [ ] `deckhand completion zsh` prints a valid zsh completion script
- [ ] `deckhand completion fish` prints a valid fish completion script
- [ ] `deckhand --help` lists `completion` as an available command

🤖 Generated with [Claude Code](https://claude.com/claude-code)