### PR TITLE
feat: shared external Docker network with static IPs for SSH access

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26
 
 require (
 	github.com/charmbracelet/huh v1.0.0
+	github.com/containerd/errdefs v1.0.0
 	github.com/knadh/koanf/parsers/yaml v1.1.0
 	github.com/knadh/koanf/providers/file v1.2.1
 	github.com/knadh/koanf/v2 v2.3.3
@@ -31,7 +32,6 @@ require (
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
-	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/dnephin/pflag v1.0.7 // indirect

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -61,6 +61,16 @@ func (d *doctorDockerChecker) ComposeVersion() (string, error) {
 	return docker.NewCompose().ComposeVersion()
 }
 
+// NetworkExists implements service.DockerChecker.
+func (d *doctorDockerChecker) NetworkExists(name string) (bool, error) {
+	client, err := docker.NewClient(context.Background())
+	if err != nil {
+		return false, err
+	}
+	defer client.Close()
+	return docker.NewNetwork(client.API()).NetworkExists(name)
+}
+
 // doctorConfigLoader adapts real config loading to the service.ConfigLoader interface.
 type doctorConfigLoader struct{}
 

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -61,7 +61,10 @@ func newEnvironmentService(proj domain.Project, dir string) (*service.Environmen
 
 	cleanup := func() {}
 	if globalCfg.Network.IsConfigured() {
-		statePath, _ := config.NetworkStatePath()
+		statePath, pathErr := config.NetworkStatePath()
+		if pathErr != nil {
+			return nil, nil, fmt.Errorf("resolving network state path: %w", pathErr)
+		}
 		client, clientErr := docker.NewClient(context.Background())
 		if clientErr != nil {
 			return nil, nil, fmt.Errorf("connecting to docker: %w", clientErr)
@@ -128,7 +131,11 @@ func newEnvironmentServiceWithVolumes(proj domain.Project, dir string) (*service
 	svc.SetLogger(stderrLogger)
 
 	if globalCfg.Network.IsConfigured() {
-		statePath, _ := config.NetworkStatePath()
+		statePath, pathErr := config.NetworkStatePath()
+		if pathErr != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("resolving network state path: %w", pathErr)
+		}
 		svc.SetNetworkSupport(nil, statePath) // No checker needed for destroy.
 	}
 

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -41,11 +41,13 @@ func stderrLogger(format string, args ...any) {
 }
 
 // newEnvironmentService creates an EnvironmentService wired to real infra.
-// It loads the global config for mount merging during Up.
-func newEnvironmentService(proj domain.Project, dir string) (*service.EnvironmentService, error) {
+// It loads the global config for mount merging during Up. If the global
+// config has a network block, it also wires up a Docker network checker
+// and the network state path.
+func newEnvironmentService(proj domain.Project, dir string) (*service.EnvironmentService, func(), error) {
 	globalCfg, err := loadGlobalConfig()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	svc := service.NewEnvironmentService(
 		templateSourceForProject(dir),
@@ -56,7 +58,19 @@ func newEnvironmentService(proj domain.Project, dir string) (*service.Environmen
 		dir,
 	)
 	svc.SetLogger(stderrLogger)
-	return svc, nil
+
+	cleanup := func() {}
+	if globalCfg.Network.IsConfigured() {
+		statePath, _ := config.NetworkStatePath()
+		client, clientErr := docker.NewClient(context.Background())
+		if clientErr != nil {
+			return nil, nil, fmt.Errorf("connecting to docker: %w", clientErr)
+		}
+		cleanup = func() { _ = client.Close() }
+		svc.SetNetworkSupport(docker.NewNetwork(client.API()), statePath)
+	}
+
+	return svc, cleanup, nil
 }
 
 // newEnvironmentServiceForDown creates a lightweight EnvironmentService for
@@ -89,8 +103,13 @@ func loadGlobalConfig() (domain.GlobalConfig, error) {
 
 // newEnvironmentServiceWithVolumes creates an EnvironmentService with volume
 // management support. Used by destroy which needs to discover and remove
-// labeled volumes. Does not load global config — destroy doesn't use mounts.
+// labeled volumes and free network IPs.
 func newEnvironmentServiceWithVolumes(proj domain.Project, dir string) (*service.EnvironmentService, func(), error) {
+	globalCfg, err := loadGlobalConfig()
+	if err != nil {
+		return nil, nil, err
+	}
+
 	client, err := docker.NewClient(context.Background())
 	if err != nil {
 		return nil, nil, fmt.Errorf("connecting to docker: %w", err)
@@ -102,11 +121,17 @@ func newEnvironmentServiceWithVolumes(proj domain.Project, dir string) (*service
 		templateSourceForProject(dir),
 		docker.NewCompose(),
 		volMgr,
-		domain.GlobalConfig{},
+		globalCfg,
 		proj,
 		dir,
 	)
 	svc.SetLogger(stderrLogger)
+
+	if globalCfg.Network.IsConfigured() {
+		statePath, _ := config.NetworkStatePath()
+		svc.SetNetworkSupport(nil, statePath) // No checker needed for destroy.
+	}
+
 	return svc, cleanup, nil
 }
 

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/TomasGrbalik/deckhand/internal/config"
 	"github.com/TomasGrbalik/deckhand/internal/domain"
+	"github.com/TomasGrbalik/deckhand/internal/service"
 )
 
 func newListCmd() *cobra.Command {
@@ -32,14 +34,35 @@ func newListCmd() *cobra.Command {
 				return nil
 			}
 
+			// Check if network is configured for IP column.
+			globalCfg, _ := loadGlobalConfig()
+			var networkState *service.NetworkState
+			if globalCfg.Network.IsConfigured() {
+				statePath, pathErr := config.NetworkStatePath()
+				if pathErr == nil {
+					networkState, _ = service.LoadNetworkState(statePath)
+				}
+			}
+
 			// Group containers by project.
 			projects := groupByProject(containers)
 
 			out := cmd.OutOrStdout()
 			w := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
-			fmt.Fprintln(w, "PROJECT\tSTATUS\tSERVICES\tUPTIME")
-			for _, p := range projects {
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", p.name, p.status, p.services, p.uptime)
+			if networkState != nil {
+				fmt.Fprintln(w, "PROJECT\tSTATUS\tIP\tSERVICES\tUPTIME")
+				for _, p := range projects {
+					ip := service.ProjectIP(networkState, p.name)
+					if ip == "" {
+						ip = "—"
+					}
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", p.name, p.status, ip, p.services, p.uptime)
+				}
+			} else {
+				fmt.Fprintln(w, "PROJECT\tSTATUS\tSERVICES\tUPTIME")
+				for _, p := range projects {
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", p.name, p.status, p.services, p.uptime)
+				}
 			}
 			return w.Flush()
 		},

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -35,12 +35,15 @@ func newListCmd() *cobra.Command {
 			}
 
 			// Check if network is configured for IP column.
-			globalCfg, _ := loadGlobalConfig()
-			var networkState *service.NetworkState
-			if globalCfg.Network.IsConfigured() {
+			globalCfg, cfgErr := loadGlobalConfig()
+			showIPColumn := cfgErr == nil && globalCfg.Network.IsConfigured()
+			networkState := &service.NetworkState{Assignments: map[string]string{}}
+			if showIPColumn {
 				statePath, pathErr := config.NetworkStatePath()
 				if pathErr == nil {
-					networkState, _ = service.LoadNetworkState(statePath)
+					if loaded, loadErr := service.LoadNetworkState(statePath); loadErr == nil {
+						networkState = loaded
+					}
 				}
 			}
 
@@ -49,7 +52,7 @@ func newListCmd() *cobra.Command {
 
 			out := cmd.OutOrStdout()
 			w := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
-			if networkState != nil {
+			if showIPColumn {
 				fmt.Fprintln(w, "PROJECT\tSTATUS\tIP\tSERVICES\tUPTIME")
 				for _, p := range projects {
 					ip := service.ProjectIP(networkState, p.name)

--- a/internal/cli/port.go
+++ b/internal/cli/port.go
@@ -99,7 +99,9 @@ func newPortAddCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			defer cleanup()
+			if cleanup != nil {
+				defer cleanup()
+			}
 			if err := svc.Add(port, name, protocol); err != nil {
 				return err
 			}
@@ -140,7 +142,9 @@ func newPortRemoveCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			defer cleanup()
+			if cleanup != nil {
+				defer cleanup()
+			}
 			if err := svc.Remove(port); err != nil {
 				return err
 			}

--- a/internal/cli/port.go
+++ b/internal/cli/port.go
@@ -95,10 +95,11 @@ func newPortAddCmd() *cobra.Command {
 				return err
 			}
 
-			svc, err := newPortService(proj, dir)
+			svc, cleanup, err := newPortService(proj, dir)
 			if err != nil {
 				return err
 			}
+			defer cleanup()
 			if err := svc.Add(port, name, protocol); err != nil {
 				return err
 			}
@@ -135,10 +136,11 @@ func newPortRemoveCmd() *cobra.Command {
 				return err
 			}
 
-			svc, err := newPortService(proj, dir)
+			svc, cleanup, err := newPortService(proj, dir)
 			if err != nil {
 				return err
 			}
+			defer cleanup()
 			if err := svc.Remove(port); err != nil {
 				return err
 			}
@@ -151,13 +153,13 @@ func newPortRemoveCmd() *cobra.Command {
 
 // newPortService creates a PortService wired to real config persistence
 // and environment recreation.
-func newPortService(proj *domain.Project, dir string) (*service.PortService, error) {
+func newPortService(proj *domain.Project, dir string) (*service.PortService, func(), error) {
 	cfgPath := config.ProjectConfigPath(dir)
-	envSvc, err := newEnvironmentService(*proj, dir)
+	envSvc, cleanup, err := newEnvironmentService(*proj, dir)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return service.NewPortService(proj, cfgPath, configSaver{}, envSvc), nil
+	return service.NewPortService(proj, cfgPath, configSaver{}, envSvc), cleanup, nil
 }
 
 // configSaver implements service.ConfigWriter using config.Save.

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -23,10 +23,11 @@ func newUpCmd() *cobra.Command {
 				return err
 			}
 
-			svc, err := newEnvironmentService(*proj, dir)
+			svc, cleanup, err := newEnvironmentService(*proj, dir)
 			if err != nil {
 				return err
 			}
+			defer cleanup()
 
 			if err := svc.Up(build); err != nil {
 				return fmt.Errorf("starting environment: %w", err)

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -27,7 +27,9 @@ func newUpCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			defer cleanup()
+			if cleanup != nil {
+				defer cleanup()
+			}
 
 			if err := svc.Up(build); err != nil {
 				return fmt.Errorf("starting environment: %w", err)

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -27,3 +27,14 @@ func GlobalConfigPath() (string, error) {
 	}
 	return filepath.Join(configDir, "deckhand", "config.yaml"), nil
 }
+
+// NetworkStatePath returns the path to the network state file that tracks
+// project-to-IP assignments. Returns empty string if the config dir can't
+// be resolved.
+func NetworkStatePath() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(configDir, "deckhand", "network-state.yaml"), nil
+}

--- a/internal/domain/global_config.go
+++ b/internal/domain/global_config.go
@@ -6,6 +6,7 @@ type GlobalConfig struct {
 	Defaults GlobalDefaults `yaml:"defaults"`
 	SSH      SSHConfig      `yaml:"ssh"`
 	Mounts   Mounts         `yaml:"mounts"`
+	Network  NetworkConfig  `yaml:"network"`
 }
 
 // GlobalDefaults holds default settings that apply to all projects

--- a/internal/domain/network.go
+++ b/internal/domain/network.go
@@ -1,0 +1,15 @@
+package domain
+
+// NetworkConfig holds the shared Docker network settings for SSH access.
+// When configured in global config, devcontainers get a static IP on
+// this network for direct SSH access via Tailscale subnet routing.
+type NetworkConfig struct {
+	Name    string `yaml:"name"`
+	Subnet  string `yaml:"subnet"`
+	Gateway string `yaml:"gateway"`
+}
+
+// IsConfigured returns true if the network block has a name set.
+func (n NetworkConfig) IsConfigured() bool {
+	return n.Name != ""
+}

--- a/internal/domain/network.go
+++ b/internal/domain/network.go
@@ -9,7 +9,7 @@ type NetworkConfig struct {
 	Gateway string `yaml:"gateway"`
 }
 
-// IsConfigured returns true if the network block has a name set.
+// IsConfigured returns true if all required network fields are set.
 func (n NetworkConfig) IsConfigured() bool {
-	return n.Name != ""
+	return n.Name != "" && n.Subnet != "" && n.Gateway != ""
 }

--- a/internal/infra/docker/network.go
+++ b/internal/infra/docker/network.go
@@ -1,0 +1,34 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/errdefs"
+	"github.com/moby/moby/client"
+)
+
+// Network checks Docker network state.
+type Network struct {
+	api client.APIClient
+}
+
+// NewNetwork creates a Network checker using the given Docker API client.
+func NewNetwork(api client.APIClient) *Network {
+	return &Network{api: api}
+}
+
+// NetworkExists returns true if a Docker network with the given name exists.
+func (n *Network) NetworkExists(name string) (bool, error) {
+	ctx := context.Background()
+
+	_, err := n.api.NetworkInspect(ctx, name, client.NetworkInspectOptions{})
+	if err != nil {
+		if errdefs.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("inspecting network %q: %w", name, err)
+	}
+
+	return true, nil
+}

--- a/internal/infra/docker/network_test.go
+++ b/internal/infra/docker/network_test.go
@@ -1,0 +1,77 @@
+package docker_test
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	"github.com/TomasGrbalik/deckhand/internal/infra/docker"
+)
+
+const testNetworkName = "deckhand-test-net"
+
+// createTestNetwork creates a Docker network for testing and returns a cleanup function.
+func createTestNetwork(t *testing.T) func() {
+	t.Helper()
+
+	// Remove any leftover network from a previous run.
+	_ = exec.Command("docker", "network", "rm", testNetworkName).Run()
+
+	cmd := exec.Command("docker", "network", "create",
+		"--driver=bridge",
+		"--subnet=172.31.255.0/24",
+		testNetworkName,
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("creating test network: %v\n%s", err, out)
+	}
+
+	return func() {
+		_ = exec.Command("docker", "network", "rm", testNetworkName).Run()
+	}
+}
+
+func TestNetworkExists_True(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	cleanup := createTestNetwork(t)
+	defer cleanup()
+
+	client, err := docker.NewClient(context.Background())
+	if err != nil {
+		t.Fatalf("creating docker client: %v", err)
+	}
+	defer client.Close()
+
+	net := docker.NewNetwork(client.API())
+	exists, err := net.NetworkExists(testNetworkName)
+	if err != nil {
+		t.Fatalf("NetworkExists() error: %v", err)
+	}
+	if !exists {
+		t.Error("expected network to exist")
+	}
+}
+
+func TestNetworkExists_False(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	client, err := docker.NewClient(context.Background())
+	if err != nil {
+		t.Fatalf("creating docker client: %v", err)
+	}
+	defer client.Close()
+
+	net := docker.NewNetwork(client.API())
+	exists, err := net.NetworkExists("deckhand-nonexistent-net-" + t.Name())
+	if err != nil {
+		t.Fatalf("NetworkExists() error: %v", err)
+	}
+	if exists {
+		t.Error("expected network to not exist")
+	}
+}

--- a/internal/infra/template/embedded_test.go
+++ b/internal/infra/template/embedded_test.go
@@ -330,6 +330,8 @@ type templateData struct {
 	NamedVolumes     []NamedVolumeEntry
 	Companions       []CompanionTemplateData
 	CompanionVolumes []CompanionVolumeEntry
+	NetworkName      string
+	NetworkIP        string
 }
 
 // renderCompose is a test helper that loads, parses, and executes a

--- a/internal/service/doctor.go
+++ b/internal/service/doctor.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 
 	"github.com/TomasGrbalik/deckhand/internal/domain"
@@ -30,6 +31,7 @@ type CheckResult struct {
 type DockerChecker interface {
 	Ping() error
 	ComposeVersion() (string, error)
+	NetworkExists(name string) (bool, error)
 }
 
 // ConfigLoader abstracts config file loading so tests can inject fakes.
@@ -61,12 +63,15 @@ func (s *DoctorService) RunChecks(projectDir string) []CheckResult {
 
 	results = append(results, s.checkDocker())
 	results = append(results, s.checkCompose())
-	results = append(results, s.checkGlobalConfig())
+
+	globalResult, globalCfg := s.checkGlobalConfigWithResult()
+	results = append(results, globalResult)
 
 	projResult, proj := s.checkProjectConfig(projectDir)
 	results = append(results, projResult)
 
 	results = append(results, s.checkTemplate(proj))
+	results = append(results, s.checkNetwork(globalCfg))
 
 	return results
 }
@@ -112,20 +117,22 @@ func (s *DoctorService) checkCompose() CheckResult {
 	}
 }
 
-func (s *DoctorService) checkGlobalConfig() CheckResult {
-	_, err := s.config.LoadGlobal()
+// checkGlobalConfigWithResult returns the check result and the loaded config.
+// The config is passed to checkNetwork.
+func (s *DoctorService) checkGlobalConfigWithResult() (CheckResult, *domain.GlobalConfig) {
+	cfg, err := s.config.LoadGlobal()
 	if err != nil {
 		return CheckResult{
 			Name:    "Global config",
 			Status:  CheckFail,
 			Message: err.Error(),
-		}
+		}, nil
 	}
 	return CheckResult{
 		Name:    "Global config",
 		Status:  CheckPass,
 		Message: "valid",
-	}
+	}, cfg
 }
 
 // checkProjectConfig returns the check result and the loaded project (nil if
@@ -173,5 +180,39 @@ func (s *DoctorService) checkTemplate(proj *domain.Project) CheckResult {
 		Name:    "Template",
 		Status:  CheckPass,
 		Message: "template " + proj.Template + " found",
+	}
+}
+
+func (s *DoctorService) checkNetwork(cfg *domain.GlobalConfig) CheckResult {
+	if cfg == nil || !cfg.Network.IsConfigured() {
+		return CheckResult{
+			Name:    "Docker network",
+			Status:  CheckSkip,
+			Message: "no network configured in global config",
+		}
+	}
+
+	net := cfg.Network
+	exists, err := s.docker.NetworkExists(net.Name)
+	if err != nil {
+		return CheckResult{
+			Name:    "Docker network",
+			Status:  CheckFail,
+			Message: err.Error(),
+		}
+	}
+	if !exists {
+		return CheckResult{
+			Name:   "Docker network",
+			Status: CheckFail,
+			Message: fmt.Sprintf("network %q not found — create it with:\n  docker network create --driver=bridge --subnet=%s --gateway=%s %s",
+				net.Name, net.Subnet, net.Gateway, net.Name),
+		}
+	}
+
+	return CheckResult{
+		Name:    "Docker network",
+		Status:  CheckPass,
+		Message: "network " + net.Name + " exists",
 	}
 }

--- a/internal/service/doctor_test.go
+++ b/internal/service/doctor_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"errors"
 	"io/fs"
+	"strings"
 	"testing"
 
 	"github.com/TomasGrbalik/deckhand/internal/domain"
@@ -14,10 +15,15 @@ type fakeDockerChecker struct {
 	pingErr        error
 	composeVersion string
 	composeErr     error
+	networkExists  bool
+	networkErr     error
 }
 
 func (f *fakeDockerChecker) Ping() error                     { return f.pingErr }
 func (f *fakeDockerChecker) ComposeVersion() (string, error) { return f.composeVersion, f.composeErr }
+func (f *fakeDockerChecker) NetworkExists(_ string) (bool, error) {
+	return f.networkExists, f.networkErr
+}
 
 // fakeConfigLoader implements service.ConfigLoader for testing.
 type fakeConfigLoader struct {
@@ -66,16 +72,21 @@ func TestDoctorAllPass(t *testing.T) {
 
 	results := svc.RunChecks("/tmp/myapp")
 
-	if len(results) != 5 {
-		t.Fatalf("expected 5 results, got %d", len(results))
+	if len(results) != 6 {
+		t.Fatalf("expected 6 results, got %d", len(results))
 	}
 	for _, r := range results {
-		if r.Status != service.CheckPass {
-			t.Errorf("%s: expected PASS, got %s (%s)", r.Name, r.Status, r.Message)
+		if r.Status == service.CheckFail {
+			t.Errorf("%s: unexpected FAIL (%s)", r.Name, r.Message)
 		}
 	}
+	// Network check should be SKIP when no network is configured.
+	networkResult := results[5]
+	if networkResult.Status != service.CheckSkip {
+		t.Errorf("Docker network: expected SKIP (no config), got %s (%s)", networkResult.Status, networkResult.Message)
+	}
 	if service.HasFailures(results) {
-		t.Error("HasFailures() should be false when all checks pass")
+		t.Error("HasFailures() should be false when all checks pass or skip")
 	}
 }
 
@@ -95,8 +106,8 @@ func TestDoctorDockerFail(t *testing.T) {
 		t.Errorf("Docker daemon: expected FAIL, got %s", results[0].Status)
 	}
 	// All checks should still run.
-	if len(results) != 5 {
-		t.Fatalf("expected 5 results (no short-circuit), got %d", len(results))
+	if len(results) != 6 {
+		t.Fatalf("expected 6 results (no short-circuit), got %d", len(results))
 	}
 	if !service.HasFailures(results) {
 		t.Error("HasFailures() should be true")
@@ -201,5 +212,74 @@ func TestDoctorTemplateMissing(t *testing.T) {
 
 	if results[4].Status != service.CheckFail {
 		t.Errorf("Template: expected FAIL, got %s", results[4].Status)
+	}
+}
+
+func TestDoctorNetworkExists(t *testing.T) {
+	svc := service.NewDoctorService(
+		&fakeDockerChecker{composeVersion: "2.24.0", networkExists: true},
+		&fakeConfigLoader{
+			globalCfg: &domain.GlobalConfig{
+				Network: domain.NetworkConfig{
+					Name:    "ssh-net",
+					Subnet:  "172.30.0.0/24",
+					Gateway: "172.30.0.1",
+				},
+			},
+			projectCfg: &domain.Project{Name: "myapp", Template: "go"},
+		},
+		&fakeTemplateSource{available: map[string]bool{"go": true}},
+	)
+
+	results := svc.RunChecks("/tmp/myapp")
+
+	networkResult := results[5]
+	if networkResult.Status != service.CheckPass {
+		t.Errorf("Docker network: expected PASS, got %s (%s)", networkResult.Status, networkResult.Message)
+	}
+}
+
+func TestDoctorNetworkMissing(t *testing.T) {
+	svc := service.NewDoctorService(
+		&fakeDockerChecker{composeVersion: "2.24.0", networkExists: false},
+		&fakeConfigLoader{
+			globalCfg: &domain.GlobalConfig{
+				Network: domain.NetworkConfig{
+					Name:    "ssh-net",
+					Subnet:  "172.30.0.0/24",
+					Gateway: "172.30.0.1",
+				},
+			},
+			projectCfg: &domain.Project{Name: "myapp", Template: "go"},
+		},
+		&fakeTemplateSource{available: map[string]bool{"go": true}},
+	)
+
+	results := svc.RunChecks("/tmp/myapp")
+
+	networkResult := results[5]
+	if networkResult.Status != service.CheckFail {
+		t.Errorf("Docker network: expected FAIL, got %s (%s)", networkResult.Status, networkResult.Message)
+	}
+	if !strings.Contains(networkResult.Message, "docker network create") {
+		t.Errorf("error should include create command, got: %s", networkResult.Message)
+	}
+}
+
+func TestDoctorNetworkSkipWhenNotConfigured(t *testing.T) {
+	svc := service.NewDoctorService(
+		&fakeDockerChecker{composeVersion: "2.24.0"},
+		&fakeConfigLoader{
+			globalCfg:  &domain.GlobalConfig{},
+			projectCfg: &domain.Project{Name: "myapp", Template: "go"},
+		},
+		&fakeTemplateSource{available: map[string]bool{"go": true}},
+	)
+
+	results := svc.RunChecks("/tmp/myapp")
+
+	networkResult := results[5]
+	if networkResult.Status != service.CheckSkip {
+		t.Errorf("Docker network: expected SKIP, got %s (%s)", networkResult.Status, networkResult.Message)
 	}
 }

--- a/internal/service/environment.go
+++ b/internal/service/environment.go
@@ -39,16 +39,23 @@ type VolumeManager interface {
 	Remove(volumeName string) error
 }
 
+// NetworkChecker verifies that a Docker network exists.
+type NetworkChecker interface {
+	NetworkExists(name string) (bool, error)
+}
+
 // EnvironmentService orchestrates the full dev container lifecycle.
 // CLI commands call Up, Down, and Destroy through this service.
 type EnvironmentService struct {
-	templates    TemplateSource
-	compose      ComposeRunner
-	volumes      VolumeManager
-	project      domain.Project
-	globalConfig domain.GlobalConfig
-	projectDir   string
-	logger       func(format string, args ...any)
+	templates        TemplateSource
+	compose          ComposeRunner
+	volumes          VolumeManager
+	networkChecker   NetworkChecker
+	networkStatePath string
+	project          domain.Project
+	globalConfig     domain.GlobalConfig
+	projectDir       string
+	logger           func(format string, args ...any)
 }
 
 // NewEnvironmentService creates an EnvironmentService.
@@ -76,6 +83,14 @@ func NewEnvironmentService(
 // If not set, warnings are silently discarded.
 func (s *EnvironmentService) SetLogger(fn func(format string, args ...any)) {
 	s.logger = fn
+}
+
+// SetNetworkSupport configures Docker network checking and IP state
+// management. checker may be nil (e.g., for destroy which doesn't need
+// to verify the network). statePath is the path to network-state.yaml.
+func (s *EnvironmentService) SetNetworkSupport(checker NetworkChecker, statePath string) {
+	s.networkChecker = checker
+	s.networkStatePath = statePath
 }
 
 func (s *EnvironmentService) logf(format string, args ...any) {
@@ -110,7 +125,16 @@ func (s *EnvironmentService) Up(build bool) error {
 		s.logf("warning: %s", w)
 	}
 
-	out, err := tmplSvc.Render(s.project, resolved)
+	var renderOpts RenderOpts
+	if s.globalConfig.Network.IsConfigured() {
+		netOpts, netErr := s.allocateNetwork()
+		if netErr != nil {
+			return netErr
+		}
+		renderOpts = netOpts
+	}
+
+	out, err := tmplSvc.Render(s.project, resolved, renderOpts)
 	if err != nil {
 		return fmt.Errorf("rendering templates: %w", err)
 	}
@@ -135,6 +159,45 @@ func (s *EnvironmentService) Up(build bool) error {
 	}
 
 	return nil
+}
+
+// allocateNetwork checks that the configured Docker network exists and
+// allocates (or reuses) a static IP for this project.
+func (s *EnvironmentService) allocateNetwork() (RenderOpts, error) {
+	net := s.globalConfig.Network
+
+	if s.networkChecker != nil {
+		exists, err := s.networkChecker.NetworkExists(net.Name)
+		if err != nil {
+			return RenderOpts{}, fmt.Errorf("checking network: %w", err)
+		}
+		if !exists {
+			return RenderOpts{}, fmt.Errorf(
+				"network %q does not exist — create it with:\n  docker network create --driver=bridge --subnet=%s --gateway=%s %s",
+				net.Name, net.Subnet, net.Gateway, net.Name,
+			)
+		}
+	}
+
+	if s.networkStatePath == "" {
+		return RenderOpts{}, errors.New("network state path not configured")
+	}
+
+	state, err := LoadNetworkState(s.networkStatePath)
+	if err != nil {
+		return RenderOpts{}, fmt.Errorf("loading network state: %w", err)
+	}
+
+	ip, err := AllocateIP(state, net.Subnet, s.project.Name)
+	if err != nil {
+		return RenderOpts{}, fmt.Errorf("allocating IP: %w", err)
+	}
+
+	if err := SaveNetworkState(s.networkStatePath, state); err != nil {
+		return RenderOpts{}, fmt.Errorf("saving network state: %w", err)
+	}
+
+	return RenderOpts{NetworkName: net.Name, NetworkIP: ip}, nil
 }
 
 // ErrNoEnvironment is returned when Down or Destroy is called without a prior Up.
@@ -199,6 +262,19 @@ func (s *EnvironmentService) Destroy() error {
 			if err := s.volumes.Remove(v.Name); err != nil {
 				return fmt.Errorf("removing volume %q: %w", v.Name, err)
 			}
+		}
+	}
+
+	// Free IP from network state if configured.
+	if s.networkStatePath != "" && s.globalConfig.Network.IsConfigured() {
+		state, loadErr := LoadNetworkState(s.networkStatePath)
+		if loadErr == nil {
+			FreeIP(state, s.project.Name)
+			if saveErr := SaveNetworkState(s.networkStatePath, state); saveErr != nil {
+				s.logf("warning: failed to save network state: %v", saveErr)
+			}
+		} else {
+			s.logf("warning: failed to load network state: %v", loadErr)
 		}
 	}
 

--- a/internal/service/environment.go
+++ b/internal/service/environment.go
@@ -268,13 +268,12 @@ func (s *EnvironmentService) Destroy() error {
 	// Free IP from network state if configured.
 	if s.networkStatePath != "" && s.globalConfig.Network.IsConfigured() {
 		state, loadErr := LoadNetworkState(s.networkStatePath)
-		if loadErr == nil {
-			FreeIP(state, s.project.Name)
-			if saveErr := SaveNetworkState(s.networkStatePath, state); saveErr != nil {
-				s.logf("warning: failed to save network state: %v", saveErr)
-			}
-		} else {
-			s.logf("warning: failed to load network state: %v", loadErr)
+		if loadErr != nil {
+			return fmt.Errorf("loading network state for IP release: %w", loadErr)
+		}
+		FreeIP(state, s.project.Name)
+		if saveErr := SaveNetworkState(s.networkStatePath, state); saveErr != nil {
+			return fmt.Errorf("saving network state after IP release: %w", saveErr)
 		}
 	}
 

--- a/internal/service/environment_test.go
+++ b/internal/service/environment_test.go
@@ -627,3 +627,186 @@ func TestUp_UnresolvableSecretLogsWarning(t *testing.T) {
 		t.Errorf("compose file not rendered correctly\nGot:\n%s", composeYAML)
 	}
 }
+
+// --- Network lifecycle tests ---
+
+// fakeNetworkChecker implements service.NetworkChecker for testing.
+type fakeNetworkChecker struct {
+	exists bool
+	err    error
+}
+
+func (f *fakeNetworkChecker) NetworkExists(_ string) (bool, error) {
+	return f.exists, f.err
+}
+
+func TestUp_WithNetworkAllocatesIP(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "network-state.yaml")
+	source := newFakeSource()
+	compose := &spyCompose{}
+	globalCfg := domain.GlobalConfig{
+		Network: domain.NetworkConfig{
+			Name:    "ssh-net",
+			Subnet:  "172.30.0.0/24",
+			Gateway: "172.30.0.1",
+		},
+	}
+	project := domain.Project{Name: "myapp", Template: "base"}
+	svc := service.NewEnvironmentService(source, compose, nil, globalCfg, project, dir)
+	svc.SetNetworkSupport(&fakeNetworkChecker{exists: true}, statePath)
+
+	if err := svc.Up(false); err != nil {
+		t.Fatalf("Up() error: %v", err)
+	}
+
+	// Verify compose output contains network config.
+	composeYAML, err := os.ReadFile(filepath.Join(dir, ".deckhand", "docker-compose.yml"))
+	if err != nil {
+		t.Fatalf("reading compose: %v", err)
+	}
+	content := string(composeYAML)
+	if !strings.Contains(content, "ssh-net:") {
+		t.Errorf("compose missing network name\nGot:\n%s", content)
+	}
+	if !strings.Contains(content, "ipv4_address: 172.30.0.10") {
+		t.Errorf("compose missing static IP\nGot:\n%s", content)
+	}
+
+	// Verify state file was written.
+	state, loadErr := service.LoadNetworkState(statePath)
+	if loadErr != nil {
+		t.Fatalf("LoadNetworkState() error: %v", loadErr)
+	}
+	if state.Assignments["myapp"] != "172.30.0.10" {
+		t.Errorf("expected IP 172.30.0.10 in state, got %v", state.Assignments)
+	}
+}
+
+func TestUp_WithNetworkReusesExistingIP(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "network-state.yaml")
+
+	// Pre-populate state with existing assignment.
+	state := &service.NetworkState{
+		Assignments: map[string]string{"myapp": "172.30.0.15"},
+	}
+	if err := service.SaveNetworkState(statePath, state); err != nil {
+		t.Fatalf("SaveNetworkState() error: %v", err)
+	}
+
+	source := newFakeSource()
+	compose := &spyCompose{}
+	globalCfg := domain.GlobalConfig{
+		Network: domain.NetworkConfig{
+			Name:    "ssh-net",
+			Subnet:  "172.30.0.0/24",
+			Gateway: "172.30.0.1",
+		},
+	}
+	project := domain.Project{Name: "myapp", Template: "base"}
+	svc := service.NewEnvironmentService(source, compose, nil, globalCfg, project, dir)
+	svc.SetNetworkSupport(&fakeNetworkChecker{exists: true}, statePath)
+
+	if err := svc.Up(false); err != nil {
+		t.Fatalf("Up() error: %v", err)
+	}
+
+	// Should reuse the existing IP.
+	composeYAML, _ := os.ReadFile(filepath.Join(dir, ".deckhand", "docker-compose.yml"))
+	if !strings.Contains(string(composeYAML), "ipv4_address: 172.30.0.15") {
+		t.Errorf("should reuse existing IP 172.30.0.15\nGot:\n%s", composeYAML)
+	}
+}
+
+func TestUp_NetworkDoesNotExist(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "network-state.yaml")
+	source := newFakeSource()
+	compose := &spyCompose{}
+	globalCfg := domain.GlobalConfig{
+		Network: domain.NetworkConfig{
+			Name:    "ssh-net",
+			Subnet:  "172.30.0.0/24",
+			Gateway: "172.30.0.1",
+		},
+	}
+	project := domain.Project{Name: "myapp", Template: "base"}
+	svc := service.NewEnvironmentService(source, compose, nil, globalCfg, project, dir)
+	svc.SetNetworkSupport(&fakeNetworkChecker{exists: false}, statePath)
+
+	err := svc.Up(false)
+	if err == nil {
+		t.Fatal("expected error when network doesn't exist")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("error should mention network doesn't exist, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "docker network create") {
+		t.Errorf("error should include create command, got: %v", err)
+	}
+
+	// Compose should not be called.
+	if len(compose.upCalls) != 0 {
+		t.Error("compose up should not be called when network doesn't exist")
+	}
+}
+
+func TestUp_NoNetworkConfigured(t *testing.T) {
+	svc, compose, dir := newTestEnv(t)
+
+	if err := svc.Up(false); err != nil {
+		t.Fatalf("Up() error: %v", err)
+	}
+
+	// Should work normally without network config.
+	composeYAML, _ := os.ReadFile(filepath.Join(dir, ".deckhand", "docker-compose.yml"))
+	if strings.Contains(string(composeYAML), "networks:") {
+		t.Errorf("compose should not have networks section\nGot:\n%s", composeYAML)
+	}
+	if len(compose.upCalls) != 1 {
+		t.Fatalf("expected 1 Up call, got %d", len(compose.upCalls))
+	}
+}
+
+func TestDestroy_FreesIP(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "network-state.yaml")
+
+	// Pre-populate state.
+	state := &service.NetworkState{
+		Assignments: map[string]string{
+			"myapp": "172.30.0.10",
+			"other": "172.30.0.11",
+		},
+	}
+	if err := service.SaveNetworkState(statePath, state); err != nil {
+		t.Fatalf("SaveNetworkState() error: %v", err)
+	}
+
+	source := newFakeSource()
+	compose := &spyCompose{}
+	globalCfg := domain.GlobalConfig{
+		Network: domain.NetworkConfig{
+			Name:    "ssh-net",
+			Subnet:  "172.30.0.0/24",
+			Gateway: "172.30.0.1",
+		},
+	}
+	project := domain.Project{Name: "myapp", Template: "base"}
+	svc := service.NewEnvironmentService(source, compose, nil, globalCfg, project, dir)
+	svc.SetNetworkSupport(nil, statePath)
+
+	if err := svc.Destroy(); err != nil {
+		t.Fatalf("Destroy() error: %v", err)
+	}
+
+	// Verify IP was freed.
+	loaded, _ := service.LoadNetworkState(statePath)
+	if _, ok := loaded.Assignments["myapp"]; ok {
+		t.Error("myapp IP should be freed after destroy")
+	}
+	if loaded.Assignments["other"] != "172.30.0.11" {
+		t.Error("other project IP should be unchanged")
+	}
+}

--- a/internal/service/network.go
+++ b/internal/service/network.go
@@ -1,0 +1,112 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+	"os"
+	"path/filepath"
+
+	goyaml "gopkg.in/yaml.v3"
+)
+
+// NetworkState tracks which project has which IP on the shared network.
+// Persisted at ~/.config/deckhand/network-state.yaml.
+type NetworkState struct {
+	Assignments map[string]string `yaml:"assignments"`
+}
+
+// LoadNetworkState reads the network state file. Returns an empty state
+// (not an error) if the file does not exist.
+func LoadNetworkState(path string) (*NetworkState, error) {
+	state := &NetworkState{Assignments: make(map[string]string)}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return state, nil
+		}
+		return nil, fmt.Errorf("reading network state %s: %w", path, err)
+	}
+
+	if err := goyaml.Unmarshal(data, state); err != nil {
+		return nil, fmt.Errorf("parsing network state %s: %w", path, err)
+	}
+
+	if state.Assignments == nil {
+		state.Assignments = make(map[string]string)
+	}
+
+	return state, nil
+}
+
+// SaveNetworkState writes the network state file, creating parent
+// directories if needed.
+func SaveNetworkState(path string, state *NetworkState) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("creating state directory: %w", err)
+	}
+
+	data, err := goyaml.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("marshaling network state: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("writing network state %s: %w", path, err)
+	}
+
+	return nil
+}
+
+// ipOffset is the first host offset used for allocation (.10).
+const ipOffset = 10
+
+// AllocateIP returns the existing IP for the project, or assigns the next
+// free one starting at .10 in the configured subnet. The state is mutated
+// in place — the caller must call SaveNetworkState afterward.
+func AllocateIP(state *NetworkState, subnet, projectName string) (string, error) {
+	if ip, ok := state.Assignments[projectName]; ok {
+		return ip, nil
+	}
+
+	prefix, err := netip.ParsePrefix(subnet)
+	if err != nil {
+		return "", fmt.Errorf("invalid subnet %q: %w", subnet, err)
+	}
+
+	used := make(map[netip.Addr]bool, len(state.Assignments))
+	for _, ip := range state.Assignments {
+		addr, parseErr := netip.ParseAddr(ip)
+		if parseErr == nil {
+			used[addr] = true
+		}
+	}
+
+	// Start at base + ipOffset (e.g., 172.30.0.10).
+	candidate := prefix.Addr()
+	for range ipOffset {
+		candidate = candidate.Next()
+	}
+
+	for prefix.Contains(candidate) {
+		if !used[candidate] {
+			state.Assignments[projectName] = candidate.String()
+			return candidate.String(), nil
+		}
+		candidate = candidate.Next()
+	}
+
+	return "", fmt.Errorf("no free IPs in subnet %s", subnet)
+}
+
+// FreeIP removes a project's IP assignment from the state.
+// The caller must call SaveNetworkState afterward.
+func FreeIP(state *NetworkState, projectName string) {
+	delete(state.Assignments, projectName)
+}
+
+// ProjectIP returns the assigned IP for a project, or empty string if none.
+func ProjectIP(state *NetworkState, projectName string) string {
+	return state.Assignments[projectName]
+}

--- a/internal/service/network.go
+++ b/internal/service/network.go
@@ -83,6 +83,8 @@ func AllocateIP(state *NetworkState, subnet, projectName string) (string, error)
 		}
 	}
 
+	broadcast := broadcastAddr(prefix)
+
 	// Start at base + ipOffset (e.g., 172.30.0.10).
 	candidate := prefix.Addr()
 	for range ipOffset {
@@ -90,7 +92,7 @@ func AllocateIP(state *NetworkState, subnet, projectName string) (string, error)
 	}
 
 	for prefix.Contains(candidate) {
-		if !used[candidate] {
+		if candidate != broadcast && !used[candidate] {
 			state.Assignments[projectName] = candidate.String()
 			return candidate.String(), nil
 		}
@@ -109,4 +111,17 @@ func FreeIP(state *NetworkState, projectName string) {
 // ProjectIP returns the assigned IP for a project, or empty string if none.
 func ProjectIP(state *NetworkState, projectName string) string {
 	return state.Assignments[projectName]
+}
+
+// broadcastAddr computes the broadcast address for an IPv4 prefix.
+// For example, 172.30.0.0/24 → 172.30.0.255.
+func broadcastAddr(prefix netip.Prefix) netip.Addr {
+	addr := prefix.Addr()
+	bits := prefix.Bits()
+	b := addr.As4()
+	// Set host bits to 1.
+	for i := bits; i < 32; i++ {
+		b[i/8] |= 1 << (7 - i%8)
+	}
+	return netip.AddrFrom4(b)
 }

--- a/internal/service/network_test.go
+++ b/internal/service/network_test.go
@@ -1,0 +1,201 @@
+package service_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/TomasGrbalik/deckhand/internal/service"
+)
+
+func TestAllocateIP_FirstProject(t *testing.T) {
+	state := &service.NetworkState{Assignments: map[string]string{}}
+
+	ip, err := service.AllocateIP(state, "172.30.0.0/24", "myapp")
+	if err != nil {
+		t.Fatalf("AllocateIP() error: %v", err)
+	}
+
+	if ip != "172.30.0.10" {
+		t.Errorf("expected 172.30.0.10, got %s", ip)
+	}
+
+	if state.Assignments["myapp"] != "172.30.0.10" {
+		t.Errorf("state not updated, got %v", state.Assignments)
+	}
+}
+
+func TestAllocateIP_SecondProject(t *testing.T) {
+	state := &service.NetworkState{
+		Assignments: map[string]string{
+			"first": "172.30.0.10",
+		},
+	}
+
+	ip, err := service.AllocateIP(state, "172.30.0.0/24", "second")
+	if err != nil {
+		t.Fatalf("AllocateIP() error: %v", err)
+	}
+
+	if ip != "172.30.0.11" {
+		t.Errorf("expected 172.30.0.11, got %s", ip)
+	}
+}
+
+func TestAllocateIP_ReusesExistingIP(t *testing.T) {
+	state := &service.NetworkState{
+		Assignments: map[string]string{
+			"myapp": "172.30.0.10",
+		},
+	}
+
+	ip, err := service.AllocateIP(state, "172.30.0.0/24", "myapp")
+	if err != nil {
+		t.Fatalf("AllocateIP() error: %v", err)
+	}
+
+	if ip != "172.30.0.10" {
+		t.Errorf("expected reused IP 172.30.0.10, got %s", ip)
+	}
+}
+
+func TestAllocateIP_SkipsUsedIPs(t *testing.T) {
+	state := &service.NetworkState{
+		Assignments: map[string]string{
+			"a": "172.30.0.10",
+			"b": "172.30.0.11",
+			"c": "172.30.0.12",
+		},
+	}
+
+	ip, err := service.AllocateIP(state, "172.30.0.0/24", "d")
+	if err != nil {
+		t.Fatalf("AllocateIP() error: %v", err)
+	}
+
+	if ip != "172.30.0.13" {
+		t.Errorf("expected 172.30.0.13, got %s", ip)
+	}
+}
+
+func TestAllocateIP_FillsGaps(t *testing.T) {
+	state := &service.NetworkState{
+		Assignments: map[string]string{
+			"a": "172.30.0.10",
+			// 172.30.0.11 is free (was freed)
+			"c": "172.30.0.12",
+		},
+	}
+
+	ip, err := service.AllocateIP(state, "172.30.0.0/24", "new")
+	if err != nil {
+		t.Fatalf("AllocateIP() error: %v", err)
+	}
+
+	if ip != "172.30.0.11" {
+		t.Errorf("expected gap-fill 172.30.0.11, got %s", ip)
+	}
+}
+
+func TestAllocateIP_InvalidSubnet(t *testing.T) {
+	state := &service.NetworkState{Assignments: map[string]string{}}
+
+	_, err := service.AllocateIP(state, "not-a-subnet", "myapp")
+	if err == nil {
+		t.Fatal("expected error for invalid subnet")
+	}
+}
+
+func TestFreeIP(t *testing.T) {
+	state := &service.NetworkState{
+		Assignments: map[string]string{
+			"myapp": "172.30.0.10",
+			"other": "172.30.0.11",
+		},
+	}
+
+	service.FreeIP(state, "myapp")
+
+	if _, ok := state.Assignments["myapp"]; ok {
+		t.Error("myapp should be removed from assignments")
+	}
+	if state.Assignments["other"] != "172.30.0.11" {
+		t.Error("other project should be unchanged")
+	}
+}
+
+func TestFreeIP_NonexistentProject(_ *testing.T) {
+	state := &service.NetworkState{Assignments: map[string]string{}}
+
+	// Should not panic.
+	service.FreeIP(state, "nonexistent")
+}
+
+func TestProjectIP(t *testing.T) {
+	state := &service.NetworkState{
+		Assignments: map[string]string{
+			"myapp": "172.30.0.10",
+		},
+	}
+
+	if ip := service.ProjectIP(state, "myapp"); ip != "172.30.0.10" {
+		t.Errorf("expected 172.30.0.10, got %s", ip)
+	}
+	if ip := service.ProjectIP(state, "unknown"); ip != "" {
+		t.Errorf("expected empty string for unknown project, got %s", ip)
+	}
+}
+
+func TestLoadNetworkState_MissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nonexistent.yaml")
+
+	state, err := service.LoadNetworkState(path)
+	if err != nil {
+		t.Fatalf("LoadNetworkState() error: %v", err)
+	}
+
+	if state.Assignments == nil {
+		t.Fatal("assignments map should be initialized")
+	}
+	if len(state.Assignments) != 0 {
+		t.Errorf("expected empty assignments, got %v", state.Assignments)
+	}
+}
+
+func TestLoadAndSaveNetworkState(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.yaml")
+
+	state := &service.NetworkState{
+		Assignments: map[string]string{
+			"myapp": "172.30.0.10",
+		},
+	}
+
+	if err := service.SaveNetworkState(path, state); err != nil {
+		t.Fatalf("SaveNetworkState() error: %v", err)
+	}
+
+	loaded, err := service.LoadNetworkState(path)
+	if err != nil {
+		t.Fatalf("LoadNetworkState() error: %v", err)
+	}
+
+	if loaded.Assignments["myapp"] != "172.30.0.10" {
+		t.Errorf("expected myapp=172.30.0.10, got %v", loaded.Assignments)
+	}
+}
+
+func TestSaveNetworkState_CreatesDirectories(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sub", "dir", "state.yaml")
+
+	state := &service.NetworkState{Assignments: map[string]string{}}
+	if err := service.SaveNetworkState(path, state); err != nil {
+		t.Fatalf("SaveNetworkState() error: %v", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("state file should exist: %v", err)
+	}
+}

--- a/internal/service/network_test.go
+++ b/internal/service/network_test.go
@@ -1,6 +1,7 @@
 package service_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -94,6 +95,23 @@ func TestAllocateIP_FillsGaps(t *testing.T) {
 
 	if ip != "172.30.0.11" {
 		t.Errorf("expected gap-fill 172.30.0.11, got %s", ip)
+	}
+}
+
+func TestAllocateIP_SkipsBroadcast(t *testing.T) {
+	// /30 subnet: 172.30.0.0, .1 (gw), .2, .3 (broadcast).
+	// Starting at .10 offset won't work for /30, so use a larger subnet
+	// but fill up to just before broadcast.
+	// Use /28: 172.30.0.0 - 172.30.0.15 (broadcast = .15).
+	state := &service.NetworkState{Assignments: map[string]string{}}
+	// Fill .10 through .14
+	for i := 10; i <= 14; i++ {
+		state.Assignments[fmt.Sprintf("proj%d", i)] = fmt.Sprintf("172.30.0.%d", i)
+	}
+	// Next candidate would be .15 (broadcast) — should be skipped.
+	_, err := service.AllocateIP(state, "172.30.0.0/28", "new")
+	if err == nil {
+		t.Fatal("expected error — no free IPs (broadcast should be excluded)")
 	}
 }
 

--- a/internal/service/template.go
+++ b/internal/service/template.go
@@ -74,6 +74,12 @@ type CompanionVolumeEntry struct {
 	ServiceName string
 }
 
+// RenderOpts holds optional configuration for template rendering.
+type RenderOpts struct {
+	NetworkName string // Name of the external Docker network (empty = no network)
+	NetworkIP   string // Static IP for the devcontainer on the network
+}
+
 // templateData is the data structure passed to Go templates during rendering.
 // ExposedPorts contains only non-internal ports from the project config.
 // Vars contains template variables with defaults merged with project overrides.
@@ -86,6 +92,8 @@ type templateData struct {
 	NamedVolumes     []NamedVolumeEntry
 	Companions       []CompanionTemplateData
 	CompanionVolumes []CompanionVolumeEntry
+	NetworkName      string // External network name (empty if not configured)
+	NetworkIP        string // Static IP on the external network
 }
 
 // TemplateService renders project templates into Dockerfile and compose content.
@@ -105,7 +113,7 @@ func NewTemplateService(source TemplateSource, registry CompanionResolver) *Temp
 // configuration and resolved mounts. If the project has no template set, it
 // defaults to "base". Template variable defaults are merged with project
 // overrides — project values take precedence.
-func (s *TemplateService) Render(project domain.Project, mounts domain.Mounts) (*RenderedOutput, error) {
+func (s *TemplateService) Render(project domain.Project, mounts domain.Mounts, opts ...RenderOpts) (*RenderedOutput, error) {
 	name := project.Template
 	if name == "" {
 		name = "base"
@@ -124,6 +132,11 @@ func (s *TemplateService) Render(project domain.Project, mounts domain.Mounts) (
 	data, err := buildTemplateData(project, meta, mounts, s.registry)
 	if err != nil {
 		return nil, fmt.Errorf("building template data: %w", err)
+	}
+
+	if len(opts) > 0 {
+		data.NetworkName = opts[0].NetworkName
+		data.NetworkIP = opts[0].NetworkIP
 	}
 
 	dockerfile, err := render("Dockerfile", dockerfileTmpl, data)

--- a/internal/service/template_test.go
+++ b/internal/service/template_test.go
@@ -63,6 +63,12 @@ const fakeCompose = `services:
       {{ .Key }}: {{ printf "%q" .Value }}
 {{- end }}
 {{- end }}
+{{- if .NetworkName }}
+    networks:
+      default: {}
+      {{ .NetworkName }}:
+        ipv4_address: {{ .NetworkIP }}
+{{- end }}
     command: sleep infinity
 {{- range .Companions }}
 
@@ -97,6 +103,10 @@ const fakeCompose = `services:
       - {{ .ComposeEntry }}
 {{- end }}
 {{- end }}
+{{- if $.NetworkName }}
+    networks:
+      default: {}
+{{- end }}
 {{- end }}
 {{- if or .NamedVolumes .CompanionVolumes }}
 
@@ -115,6 +125,12 @@ volumes:
       dev.deckhand.project: "{{ $.Name }}"
       dev.deckhand.service: "{{ .ServiceName }}"
 {{- end }}
+{{- end }}
+{{- if .NetworkName }}
+
+networks:
+  {{ .NetworkName }}:
+    external: true
 {{- end }}
 `
 
@@ -838,5 +854,92 @@ func TestRender_CompanionEnvironmentSorted(t *testing.T) {
 
 	if dbIdx >= pwIdx || pwIdx >= userIdx {
 		t.Errorf("postgres env vars not in alphabetical order\nGot:\n%s", out.Compose)
+	}
+}
+
+// --- Network rendering tests ---
+
+func TestRender_WithNetwork(t *testing.T) {
+	svc := service.NewTemplateService(newFakeSource(), nil)
+
+	project := domain.Project{Name: "myapp", Template: "base"}
+	opts := service.RenderOpts{
+		NetworkName: "ssh-net",
+		NetworkIP:   "172.30.0.10",
+	}
+
+	out, err := svc.Render(project, domain.Mounts{}, opts)
+	if err != nil {
+		t.Fatalf("Render() error: %v", err)
+	}
+
+	// Devcontainer should have network config.
+	if !strings.Contains(out.Compose, "ssh-net:") {
+		t.Errorf("compose missing network name\nGot:\n%s", out.Compose)
+	}
+	if !strings.Contains(out.Compose, "ipv4_address: 172.30.0.10") {
+		t.Errorf("compose missing static IP\nGot:\n%s", out.Compose)
+	}
+
+	// Top-level networks block.
+	if !strings.Contains(out.Compose, "networks:\n  ssh-net:\n    external: true") {
+		t.Errorf("compose missing top-level networks block\nGot:\n%s", out.Compose)
+	}
+}
+
+func TestRender_WithNetworkAndCompanions(t *testing.T) {
+	reg := service.NewCompanionRegistry()
+	svc := service.NewTemplateService(newFakeSource(), reg)
+
+	project := domain.Project{
+		Name:     "myapp",
+		Template: "base",
+		Services: []domain.ServiceConfig{
+			{Name: "postgres", Enabled: true},
+		},
+	}
+	opts := service.RenderOpts{
+		NetworkName: "ssh-net",
+		NetworkIP:   "172.30.0.10",
+	}
+
+	out, err := svc.Render(project, domain.Mounts{}, opts)
+	if err != nil {
+		t.Fatalf("Render() error: %v", err)
+	}
+
+	// Devcontainer has dual-homed network (default + ssh-net with IP).
+	if !strings.Contains(out.Compose, "ipv4_address: 172.30.0.10") {
+		t.Errorf("compose missing devcontainer static IP\nGot:\n%s", out.Compose)
+	}
+
+	// Companion (postgres) should have networks: default only, no IP.
+	// Find the postgres section and check it has "networks:\n      default: {}"
+	pgIdx := strings.Index(out.Compose, "  postgres:")
+	if pgIdx < 0 {
+		t.Fatalf("compose missing postgres block\nGot:\n%s", out.Compose)
+	}
+	pgSection := out.Compose[pgIdx:]
+	if !strings.Contains(pgSection, "networks:\n      default: {}") {
+		t.Errorf("companion should have networks: default only\nGot:\n%s", pgSection)
+	}
+	if strings.Contains(pgSection, "ipv4_address") {
+		t.Errorf("companion should not have static IP\nGot:\n%s", pgSection)
+	}
+}
+
+func TestRender_NoNetwork(t *testing.T) {
+	svc := service.NewTemplateService(newFakeSource(), nil)
+
+	project := domain.Project{Name: "myapp", Template: "base"}
+
+	out, err := svc.Render(project, domain.Mounts{})
+	if err != nil {
+		t.Fatalf("Render() error: %v", err)
+	}
+
+	// No networks section should appear.
+	if strings.Contains(out.Compose, "networks:") {
+		t.Errorf("compose should not have networks section without network config\nGot:\n%s", out.Compose)
 	}
 }

--- a/templates/compose.yaml.tmpl
+++ b/templates/compose.yaml.tmpl
@@ -28,6 +28,12 @@ services:
       {{ .Key }}: {{ printf "%q" .Value }}
 {{- end }}
 {{- end }}
+{{- if .NetworkName }}
+    networks:
+      default: {}
+      {{ .NetworkName }}:
+        ipv4_address: {{ .NetworkIP }}
+{{- end }}
     command: sleep infinity
 {{- range .Companions }}
 
@@ -62,6 +68,10 @@ services:
       - {{ .ComposeEntry }}
 {{- end }}
 {{- end }}
+{{- if $.NetworkName }}
+    networks:
+      default: {}
+{{- end }}
 {{- end }}
 {{- if or .NamedVolumes .CompanionVolumes }}
 
@@ -80,4 +90,10 @@ volumes:
       dev.deckhand.project: "{{ $.Name }}"
       dev.deckhand.service: "{{ .ServiceName }}"
 {{- end }}
+{{- end }}
+{{- if .NetworkName }}
+
+networks:
+  {{ .NetworkName }}:
+    external: true
 {{- end }}


### PR DESCRIPTION
## Summary

- Adds opt-in shared Docker network support so devcontainers get static IPs for direct SSH access via Tailscale subnet routing
- IPs are allocated starting at `.10` in the configured subnet and persisted in `~/.config/deckhand/network-state.yaml`
- Devcontainer is dual-homed (default + external network); companions stay on default only
- `destroy` frees the IP; `list` shows an IP column; `doctor` validates the network exists

## Acceptance Criteria Coverage

| Scenario | Status |
|----------|--------|
| First `up` assigns next free IP | Covered |
| Subsequent `up` reuses IP | Covered |
| Companions on default network only | Covered |
| No network configured = no change | Covered |
| Network missing = clear error with create command | Covered |
| Doctor checks network | Covered |
| Destroy frees IP | Covered |
| List shows IP column | Covered |

## Changes

### New files
- `internal/domain/network.go` — `NetworkConfig` type with `IsConfigured()` helper
- `internal/service/network.go` — IP allocation, state file load/save, `AllocateIP`/`FreeIP`
- `internal/service/network_test.go` — Unit tests for IP allocation and state management
- `internal/infra/docker/network.go` — Docker network existence check via SDK

### Modified files
- `internal/domain/global_config.go` — Added `Network` field
- `internal/config/paths.go` — Added `NetworkStatePath()`
- `internal/service/template.go` — Added `RenderOpts` with `NetworkName`/`NetworkIP`
- `internal/service/environment.go` — Network check in `Up()`, IP freeing in `Destroy()`
- `internal/service/doctor.go` — New `checkNetwork` with create command hint
- `internal/cli/list.go` — Conditional IP column when network is configured
- `internal/cli/helpers.go` — Wiring for `NetworkChecker` and state path
- `templates/compose.yaml.tmpl` — Network blocks for devcontainer, companions, and top-level

## Test plan

- [x] `go test -short ./...` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [ ] Manual test: configure `network` in global config, create Docker network, run `deckhand up`
- [ ] Manual test: verify `deckhand list` shows IP column
- [ ] Manual test: run `deckhand destroy`, confirm IP freed from state file
- [ ] Manual test: run `deckhand doctor` with missing network, confirm create command shown

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Docker network support with automatic static IP allocation and persistent state for projects.
  * Updated list output to show project IP addresses when networks are configured.
  * Enhanced health checks to verify configured Docker networks exist and provide a suggested create command when missing.

* **Chores**
  * Updated project dependencies (go.mod).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->