### PR TITLE
feat: template metadata `command` and `exec_user` overrides

### DIFF
--- a/design/specs/2026-04-19-template-metadata-command-exec-user-design.md
+++ b/design/specs/2026-04-19-template-metadata-command-exec-user-design.md
@@ -1,0 +1,151 @@
+# Template metadata: `command` and `exec_user` overrides
+
+**Status:** Design approved
+**Date:** 2026-04-19
+**Scope:** Deckhand feature + motivating `general` template in a new `deckhand-templates` repo
+
+## Motivation
+
+Deckhand's shared `compose.yaml.tmpl` hardcodes `command: sleep infinity` on the devcontainer service. Templates that need a long-running daemon (sshd, a supervisor, a language server) currently must ship a full `compose.yaml.tmpl` override — duplicating ~90 lines of boilerplate to change one line.
+
+Related gap: `internal/infra/docker/container.go` `Exec` never sets a user, so `deckhand shell` / `exec` always use the image's `USER` directive. A template that needs `USER root` (to start sshd on :22) has no way to say "but drop shell/exec sessions into `dev`."
+
+Together these two gaps block the first-class use case of this spec's consumer: a **general-purpose Ubuntu dev container with an SSH server running so you can `ssh dev@<container-ip>` directly via Tailscale** (per `docs/networking.md`).
+
+## Goals
+
+1. Let a template declare the devcontainer's long-running command declaratively, without replacing the compose template.
+2. Let a template declare which user `deckhand shell` and `deckhand exec` should drop into, independently of the Dockerfile's `USER`.
+3. Ship a `general` template (in a new `deckhand-templates` private repo) that exercises both.
+4. Preserve byte-for-byte backwards compatibility for `base` and `python`.
+
+## Non-goals
+
+- No support for multiple devcontainer services.
+- No runtime-reconfigurable `command` (rebuild required to change).
+- No `user:` for companions — only the devcontainer.
+- No `.NET` template in this round — deferred.
+
+## Design
+
+### Metadata schema additions
+
+Two new optional top-level fields in `metadata.yaml`:
+
+```yaml
+command: <string>      # Optional. Devcontainer command. Defaults to "sleep infinity" when absent.
+exec_user: <string>    # Optional. User for `deckhand shell`/`exec`. Defaults to "" (image default user).
+```
+
+Both fields are strings; absent is equivalent to empty. The service layer applies the `sleep infinity` default so `templateData.Command` is guaranteed non-empty at template-render time — the compose template never sees the default.
+
+### Code changes — deckhand repo
+
+Branch: `feat/metadata-command-and-exec-user`. One commit, conventional-commits format:
+`feat: support command and exec_user overrides in template metadata`.
+
+1. **`internal/domain/`** — metadata struct gains `Command string` and `ExecUser string`. `templateData` (compose render input) gains `Command string`.
+2. **`internal/infra/template/`** — YAML parser reads both new fields. Absent = `""`.
+3. **`internal/service/`** —
+   - When building `templateData`, set `Command = metadata.Command; if Command == "" { Command = "sleep infinity" }`.
+   - Expose `ExecUser` on whatever service-layer surface the CLI uses for `shell`/`exec`.
+4. **`internal/infra/docker/container.go`** — extend `Exec` to accept a `user string` parameter. When non-empty, set `User:` on `ExecCreateOptions`. Update all callers.
+5. **`internal/cli/`** — `shell` and `exec` subcommands look up the project's template metadata and pass `ExecUser` down to the infra call.
+6. **`templates/compose.yaml.tmpl:37`** — replace `command: sleep infinity` with `command: {{ .Command }}`.
+7. **Tests:**
+   - Template parser: `command`/`exec_user` parsed when present, empty string when absent.
+   - Service render: default `"sleep infinity"` substituted when metadata `command` is empty; passthrough when set.
+   - Compose render: both cases produce valid YAML with the expected `command:` value.
+   - Exec infra: user flag honored when non-empty; omitted from `ExecCreateOptions` when empty.
+   - Snapshot tests for `base` and `python` rendered compose output must be unchanged.
+8. **Docs:** update `docs/custom-templates.md` metadata schema table with both fields; add a short "long-running daemon" example pointing at `general`.
+
+### Template repo — `deckhand-templates`
+
+Separate private GitHub repo (user: `TomasGrbalik`). Layout:
+
+```
+deckhand-templates/
+├── README.md          # Purpose + install (`git clone <repo> ~/.config/deckhand/templates`)
+├── .gitignore
+└── general/
+    ├── metadata.yaml
+    └── Dockerfile.tmpl
+```
+
+Install on server: `git clone git@github.com:TomasGrbalik/deckhand-templates ~/.config/deckhand/templates`. Each top-level directory becomes a discoverable template name. Initial commit on `main` is README + `.gitignore`; `general/` lands via branch `feat/general-template` → PR.
+
+### `general/metadata.yaml`
+
+```yaml
+name: general
+description: Ubuntu dev container with SSH access, claude-code, and common tools
+command: "/usr/sbin/sshd -D -e"
+exec_user: dev
+variables:
+  github_user:
+    default: "TomasGrbalik"
+    description: GitHub username whose public keys authorize SSH (ignored if authorized_keys is set)
+  authorized_keys:
+    default: ""
+    description: Explicit authorized_keys content (newline-separated). Overrides github_user when non-empty.
+mounts:
+  volumes:
+    - name: workspace
+      target: /workspace
+```
+
+### `general/Dockerfile.tmpl`
+
+- Base: `ubuntu:24.04`.
+- Single apt install: `git curl wget ripgrep build-essential zsh ca-certificates openssh-server iputils-ping jq unzip less vim htop tmux rsync sudo`, then `rm -rf /var/lib/apt/lists/*`.
+- `yq`: download architecture-correct binary from `github.com/mikefarah/yq/releases/latest/download/yq_linux_$(dpkg --print-architecture)` to `/usr/local/bin/yq`.
+- User: `groupadd -f -g 1000 dev && useradd -m -u 1000 -g dev -o -s /bin/zsh dev`; grant passwordless sudo via `/etc/sudoers.d/dev`.
+- claude-code: install as `dev` via `su - dev -c "curl -fsSL https://claude.ai/install.sh | bash"`.
+- SSH:
+  - `mkdir -p /home/dev/.ssh && chmod 700 /home/dev/.ssh && chown dev:dev /home/dev/.ssh`
+  - Go-template conditional on `.Vars.authorized_keys`:
+    - If non-empty: `echo '{{ .Vars.authorized_keys }}' > /home/dev/.ssh/authorized_keys`
+    - Else: `curl -fsSL https://github.com/{{ .Vars.github_user }}.keys > /home/dev/.ssh/authorized_keys`
+  - `chmod 600 /home/dev/.ssh/authorized_keys && chown dev:dev /home/dev/.ssh/authorized_keys`
+  - Write `/etc/ssh/sshd_config.d/deckhand.conf` with: `PasswordAuthentication no`, `PermitRootLogin no`, `AllowUsers dev`.
+  - `ssh-keygen -A` at build time — host keys baked into the image; stable across container recreations. Rotate by rebuilding (expected, infrequent).
+  - `mkdir -p /run/sshd` (sshd refuses to start without it).
+- `WORKDIR /workspace`.
+- **No final `USER` directive** — container runs as root so sshd can bind :22 and read host keys; `exec_user: dev` in metadata makes `deckhand shell`/`exec` land as dev.
+
+### Deliberate deviation from `docs/custom-templates.md`
+
+The existing guide mandates "end with `USER dev`." That convention is incompatible with a template whose primary purpose is running a daemon that requires root (sshd). Once this spec lands, the docs should note that templates which declare `exec_user` may omit the `USER` directive. This doc change is part of the deckhand PR.
+
+## Testing plan
+
+Local end-to-end on this dev machine (not a real Tailscale server):
+
+1. `go build ./... && go test ./...` on the feature branch — all pass.
+2. `go install ./cmd/deckhand` to put the feature-branch binary on `$PATH`.
+3. Install the `general` template to `~/.config/deckhand/templates/general/`.
+4. Scratch project with `.deckhand.yaml` → `template: general`, `variables: { github_user: TomasGrbalik }`.
+5. `deckhand up` — build succeeds, container starts.
+6. `deckhand exec -- ss -tlnp` — confirms sshd listening on :22.
+7. `deckhand shell` — lands as `dev`.
+8. Inside shell: `claude --version`, `jq --version`, `ping -c1 8.8.8.8`, `sudo -n true` all succeed.
+9. Verify host keys are baked: `deckhand exec -- ls /etc/ssh/ssh_host_*_key` prints files.
+10. Verify authorized_keys populated: `deckhand exec -- cat /home/dev/.ssh/authorized_keys` shows GitHub-fetched keys.
+
+Real SSH (`ssh dev@<container-ip>`) is validated post-merge on the actual Tailscale-routed server.
+
+## Rollout
+
+1. Deckhand PR merges to `main`.
+2. Tag + release (or user rebuilds from source on the target server).
+3. `deckhand-templates` repo bootstrapped; `general/` PR merges.
+4. Devbox: update deckhand binary, `git clone deckhand-templates ~/.config/deckhand/templates`.
+
+## Open questions
+
+None. All decisions settled:
+- Sshd runs by default via `command:` override (not a companion).
+- Authorized keys: GitHub fetch default, explicit-keys variable override.
+- claude-code: standalone installer (no Node in the image).
+- `exec_user` ships with `command` in one PR.

--- a/design/specs/2026-04-19-template-metadata-command-exec-user-design.md
+++ b/design/specs/2026-04-19-template-metadata-command-exec-user-design.md
@@ -37,7 +37,7 @@ command: <string>      # Optional. Devcontainer command. Defaults to "sleep infi
 exec_user: <string>    # Optional. User for `deckhand shell`/`exec`. Defaults to "" (image default user).
 ```
 
-Both fields are strings; absent is equivalent to empty. The service layer applies the `sleep infinity` default so `templateData.Command` is guaranteed non-empty at template-render time — the compose template never sees the default.
+Both fields are strings; absent is equivalent to empty. The service layer sets `templateData.Command` to the metadata value, falling back to `sleep infinity` when empty, before rendering — so the compose template reads `.Command` unconditionally and always sees a non-empty value.
 
 ### Code changes — deckhand repo
 
@@ -64,7 +64,7 @@ Branch: `feat/metadata-command-and-exec-user`. One commit, conventional-commits 
 
 Separate private GitHub repo (user: `TomasGrbalik`). Layout:
 
-```
+```text
 deckhand-templates/
 ├── README.md          # Purpose + install (`git clone <repo> ~/.config/deckhand/templates`)
 ├── .gitignore

--- a/docs/custom-templates.md
+++ b/docs/custom-templates.md
@@ -64,6 +64,17 @@ mounts:
   volumes:
     - name: <string>        # Volume identifier (prefixed with project name in Compose).
       target: <string>      # Mount path inside the container.
+
+# Optional. Overrides the devcontainer's long-running command. When absent,
+# deckhand uses "sleep infinity". Use this for templates that need to run a
+# daemon (sshd, a supervisor, etc.) without overriding compose.yaml.tmpl.
+command: <string>
+
+# Optional. User that `deckhand shell` and `deckhand exec` drop into. When
+# empty, the image's default user (Dockerfile `USER` directive) is used.
+# Pair with `command` when the container must start as root but you want
+# interactive sessions as a non-root user.
+exec_user: <string>
 ```
 
 ### Example
@@ -301,6 +312,22 @@ Python container based on `python:<version>-slim`. Includes pyright and debugpy.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `python_version` | `3.12` | Python version to install |
+
+## Long-running daemons (`command` + `exec_user`)
+
+Most templates are happy with the default `sleep infinity` devcontainer command — you build the image, the container sits idle, and `deckhand shell` / `exec` drop you in. Templates that run a service (sshd, a language server, a queue worker) can declare it declaratively:
+
+```yaml
+# metadata.yaml
+name: sshd-box
+command: "/usr/sbin/sshd -D -e"
+exec_user: dev
+```
+
+- `command` replaces the hardcoded `sleep infinity` in the rendered compose file. No `compose.yaml.tmpl` override needed.
+- `exec_user` tells `deckhand shell` and `deckhand exec` to run as that user, regardless of the Dockerfile's `USER` directive. This matters when a daemon requires root (e.g., sshd binding :22 and reading host keys) but you still want interactive sessions as `dev`.
+
+In that scenario, omit the final `USER dev` from your Dockerfile so the container starts as root; `exec_user: dev` ensures your shells still land in the non-root user.
 
 ## Best Practices
 

--- a/docs/custom-templates.md
+++ b/docs/custom-templates.md
@@ -329,6 +329,17 @@ exec_user: dev
 
 In that scenario, omit the final `USER dev` from your Dockerfile so the container starts as root; `exec_user: dev` ensures your shells still land in the non-root user.
 
+### PID 1 and signal handling
+
+A string `command` (like the sshd example above) is passed to Compose as **shell form**: Compose wraps it in `/bin/sh -c "..."`, so your daemon runs as a child of `sh`, not as PID 1. When deckhand stops the container, `docker stop` sends `SIGTERM` to PID 1 (the shell), which doesn't propagate to your daemon — you get a 10 s wait followed by `SIGKILL`. That's usually tolerable for a dev container but not ideal.
+
+Two ways to make the daemon PID 1 with a string `command`:
+
+1. Prefix with `exec`: `command: "exec /usr/sbin/sshd -D -e"` — the shell replaces itself with your process.
+2. Have the daemon be an init-friendly binary directly: `command: "/usr/sbin/sshd -D -e"` works but with the caveat above.
+
+For true **exec form** (a YAML list, no shell wrapper) you still need to ship a `compose.yaml.tmpl` override — `command:` in `metadata.yaml` is string-only.
+
 ## Best Practices
 
 - **Use slim base images** and clean up package manager caches (`rm -rf /var/lib/apt/lists/*`) to keep images small and builds fast.

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -28,7 +28,12 @@ func newExecCmd() *cobra.Command {
 			}
 			defer cleanup()
 
-			if err := svc.Exec(proj.Name, "devcontainer", args); err != nil {
+			execUser, err := resolveExecUser(dir, proj.Template)
+			if err != nil {
+				return err
+			}
+
+			if err := svc.Exec(proj.Name, "devcontainer", args, execUser); err != nil {
 				return fmt.Errorf("exec: %w", err)
 			}
 

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -170,6 +170,22 @@ func (a *volumeListerAdapter) Remove(volumeName string) error {
 	return a.vol.Remove(volumeName)
 }
 
+// resolveExecUser looks up the ExecUser declared in the project's template
+// metadata. Returns empty string when the project has no template set or when
+// the metadata doesn't declare exec_user. The template name defaults to "base"
+// matching TemplateService.Render to keep behavior consistent.
+func resolveExecUser(projectDir, templateName string) (string, error) {
+	name := templateName
+	if name == "" {
+		name = "base"
+	}
+	meta, err := templateSourceForProject(projectDir).LoadMeta(name)
+	if err != nil {
+		return "", fmt.Errorf("loading template metadata for %q: %w", name, err)
+	}
+	return meta.ExecUser, nil
+}
+
 // newContainerService creates a ContainerService wired to a real Docker client.
 func newContainerService() (*service.ContainerService, func(), error) {
 	client, err := docker.NewClient(context.Background())

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -31,7 +31,12 @@ func newShellCmd() *cobra.Command {
 			}
 			defer cleanup()
 
-			if err := svc.Shell(proj.Name, serviceName, strings.Fields(shellCmd)); err != nil {
+			execUser, err := resolveExecUser(dir, proj.Template)
+			if err != nil {
+				return err
+			}
+
+			if err := svc.Shell(proj.Name, serviceName, strings.Fields(shellCmd), execUser); err != nil {
 				return fmt.Errorf("shell: %w", err)
 			}
 

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -31,9 +31,15 @@ func newShellCmd() *cobra.Command {
 			}
 			defer cleanup()
 
-			execUser, err := resolveExecUser(dir, proj.Template)
-			if err != nil {
-				return err
+			// exec_user is a devcontainer-scoped property of the project's
+			// template. Companion services (postgres, redis, ...) have their
+			// own image users and shouldn't inherit it.
+			var execUser string
+			if serviceName == "devcontainer" {
+				execUser, err = resolveExecUser(dir, proj.Template)
+				if err != nil {
+					return err
+				}
 			}
 
 			if err := svc.Shell(proj.Name, serviceName, strings.Fields(shellCmd), execUser); err != nil {

--- a/internal/domain/project.go
+++ b/internal/domain/project.go
@@ -25,6 +25,14 @@ type TemplateMeta struct {
 	Description string                      `yaml:"description"`
 	Variables   map[string]TemplateVariable `yaml:"variables"`
 	Mounts      Mounts                      `yaml:"mounts,omitempty"`
+	// Command overrides the devcontainer's long-running command in the
+	// rendered compose file. When empty, the service layer defaults to
+	// "sleep infinity".
+	Command string `yaml:"command,omitempty"`
+	// ExecUser is the user that `deckhand shell` and `deckhand exec` drop
+	// into, independent of the Dockerfile's USER directive. Empty means the
+	// image's default user is used.
+	ExecUser string `yaml:"exec_user,omitempty"`
 }
 
 // TemplateInfo describes a discovered template for listing purposes.

--- a/internal/infra/docker/container.go
+++ b/internal/infra/docker/container.go
@@ -45,8 +45,9 @@ func NewContainer(api client.APIClient) *Container {
 
 // Exec runs a command inside a container, identified by name or ID.
 // When tty is true, stdin is attached and the terminal is put into raw mode
-// for interactive use.
-func (c *Container) Exec(containerName string, cmd []string, tty bool) error {
+// for interactive use. When user is non-empty, the exec runs as that user;
+// empty falls back to the container image's default user.
+func (c *Container) Exec(containerName string, cmd []string, tty bool, user string) error {
 	ctx := context.Background()
 
 	execCfg := client.ExecCreateOptions{
@@ -55,6 +56,7 @@ func (c *Container) Exec(containerName string, cmd []string, tty bool) error {
 		AttachStdout: true,
 		AttachStderr: true,
 		TTY:          tty,
+		User:         user,
 	}
 
 	execID, err := c.api.ExecCreate(ctx, containerName, execCfg)

--- a/internal/infra/docker/container_test.go
+++ b/internal/infra/docker/container_test.go
@@ -109,7 +109,7 @@ func TestExecNonInteractive(t *testing.T) {
 
 	ctr := docker.NewContainer(cli.API())
 	// Run a simple command without TTY.
-	err = ctr.Exec(name, []string{"echo", "hello"}, false)
+	err = ctr.Exec(name, []string{"echo", "hello"}, false, "")
 	if err != nil {
 		t.Fatalf("Exec() error: %v", err)
 	}
@@ -127,7 +127,7 @@ func TestExecContainerNotFound(t *testing.T) {
 	defer cli.Close()
 
 	ctr := docker.NewContainer(cli.API())
-	err = ctr.Exec("nonexistent-container-xyz", []string{"echo", "hello"}, false)
+	err = ctr.Exec("nonexistent-container-xyz", []string{"echo", "hello"}, false, "")
 	if err == nil {
 		t.Fatal("expected error for nonexistent container")
 	}

--- a/internal/infra/docker/container_test.go
+++ b/internal/infra/docker/container_test.go
@@ -113,6 +113,12 @@ func TestExecNonInteractive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Exec() error: %v", err)
 	}
+
+	// Explicit user: root is always present in alpine, exercises the
+	// ExecCreateOptions.User path.
+	if err := ctr.Exec(name, []string{"true"}, false, "root"); err != nil {
+		t.Fatalf("Exec() with user=root error: %v", err)
+	}
 }
 
 func TestExecContainerNotFound(t *testing.T) {

--- a/internal/infra/template/embedded_test.go
+++ b/internal/infra/template/embedded_test.go
@@ -332,12 +332,20 @@ type templateData struct {
 	CompanionVolumes []CompanionVolumeEntry
 	NetworkName      string
 	NetworkIP        string
+	Command          string
 }
 
 // renderCompose is a test helper that loads, parses, and executes a
 // compose template with the given data.
 func renderCompose(t *testing.T, templateName string, data templateData) string {
 	t.Helper()
+
+	// The compose template always reads .Command; the service layer is
+	// responsible for defaulting it. In these tests we mimic that default
+	// so callers don't have to set it explicitly.
+	if data.Command == "" {
+		data.Command = "sleep infinity"
+	}
 
 	_, composeTmpl, err := tmpl.Load(templateName)
 	if err != nil {

--- a/internal/infra/template/filesystem_test.go
+++ b/internal/infra/template/filesystem_test.go
@@ -299,3 +299,56 @@ func TestEmbeddedSource_List(t *testing.T) {
 		t.Error("base template not found in embedded listing")
 	}
 }
+
+func TestFilesystemSource_LoadMeta_ParsesCommandAndExecUser(t *testing.T) {
+	dir := t.TempDir()
+	tmplDir := filepath.Join(dir, "daemon")
+	if err := os.Mkdir(tmplDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	meta := `name: daemon
+description: runs a daemon
+command: "/usr/sbin/sshd -D -e"
+exec_user: dev
+variables: {}
+`
+	if err := os.WriteFile(filepath.Join(tmplDir, "metadata.yaml"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := &tmpl.FilesystemSource{Dir: dir}
+	got, err := fs.LoadMeta("daemon")
+	if err != nil {
+		t.Fatalf("LoadMeta() error: %v", err)
+	}
+	if got.Command != "/usr/sbin/sshd -D -e" {
+		t.Errorf("Command = %q, want %q", got.Command, "/usr/sbin/sshd -D -e")
+	}
+	if got.ExecUser != "dev" {
+		t.Errorf("ExecUser = %q, want %q", got.ExecUser, "dev")
+	}
+}
+
+func TestFilesystemSource_LoadMeta_AbsentCommandAndExecUser(t *testing.T) {
+	dir := t.TempDir()
+	tmplDir := filepath.Join(dir, "plain")
+	if err := os.Mkdir(tmplDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	meta := "name: plain\ndescription: plain template\nvariables: {}\n"
+	if err := os.WriteFile(filepath.Join(tmplDir, "metadata.yaml"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := &tmpl.FilesystemSource{Dir: dir}
+	got, err := fs.LoadMeta("plain")
+	if err != nil {
+		t.Fatalf("LoadMeta() error: %v", err)
+	}
+	if got.Command != "" {
+		t.Errorf("Command = %q, want empty", got.Command)
+	}
+	if got.ExecUser != "" {
+		t.Errorf("ExecUser = %q, want empty", got.ExecUser)
+	}
+}

--- a/internal/service/container.go
+++ b/internal/service/container.go
@@ -9,7 +9,7 @@ import (
 // provides the real implementation; tests use a fake.
 type ContainerRunner interface {
 	FindContainer(projectName, serviceName string) (string, error)
-	Exec(containerName string, cmd []string, tty bool) error
+	Exec(containerName string, cmd []string, tty bool, user string) error
 	Logs(containerName string, follow bool, tail string) (io.ReadCloser, error)
 }
 
@@ -28,15 +28,15 @@ func NewContainerService(runner ContainerRunner) *ContainerService {
 
 // Shell opens an interactive shell in the container for the given project
 // and service. The cmd parameter is the shell command and any args
-// (e.g. []string{"bash", "-l"}). No defaulting is done here — the caller
-// provides the shell to use.
-func (s *ContainerService) Shell(project, service string, cmd []string) error {
+// (e.g. []string{"bash", "-l"}). When user is non-empty, the shell runs as
+// that user; otherwise the image's default user is used.
+func (s *ContainerService) Shell(project, service string, cmd []string, user string) error {
 	containerID, err := s.runner.FindContainer(project, service)
 	if err != nil {
 		return fmt.Errorf("finding container: %w", err)
 	}
 
-	if err := s.runner.Exec(containerID, cmd, true); err != nil {
+	if err := s.runner.Exec(containerID, cmd, true, user); err != nil {
 		return fmt.Errorf("shell exec: %w", err)
 	}
 
@@ -44,14 +44,14 @@ func (s *ContainerService) Shell(project, service string, cmd []string) error {
 }
 
 // Exec runs a command (without TTY) in the container for the given project
-// and service.
-func (s *ContainerService) Exec(project, service string, cmd []string) error {
+// and service. When user is non-empty, the command runs as that user.
+func (s *ContainerService) Exec(project, service string, cmd []string, user string) error {
 	containerID, err := s.runner.FindContainer(project, service)
 	if err != nil {
 		return fmt.Errorf("finding container: %w", err)
 	}
 
-	if err := s.runner.Exec(containerID, cmd, false); err != nil {
+	if err := s.runner.Exec(containerID, cmd, false, user); err != nil {
 		return fmt.Errorf("exec: %w", err)
 	}
 

--- a/internal/service/container_test.go
+++ b/internal/service/container_test.go
@@ -31,6 +31,7 @@ type execCall struct {
 	containerName string
 	cmd           []string
 	tty           bool
+	user          string
 }
 
 type logsCall struct {
@@ -44,8 +45,8 @@ func (f *spyRunner) FindContainer(project, svc string) (string, error) {
 	return f.findResult, f.findErr
 }
 
-func (f *spyRunner) Exec(containerName string, cmd []string, tty bool) error {
-	f.execCalls = append(f.execCalls, execCall{containerName, cmd, tty})
+func (f *spyRunner) Exec(containerName string, cmd []string, tty bool, user string) error {
+	f.execCalls = append(f.execCalls, execCall{containerName, cmd, tty, user})
 	return f.execErr
 }
 
@@ -64,7 +65,7 @@ func newTestContainer(t *testing.T) (*service.ContainerService, *spyRunner) {
 func TestShell_FindsContainerAndExecsWithTTY(t *testing.T) {
 	svc, runner := newTestContainer(t)
 
-	if err := svc.Shell("myapp", "devcontainer", []string{"zsh"}); err != nil {
+	if err := svc.Shell("myapp", "devcontainer", []string{"zsh"}, ""); err != nil {
 		t.Fatalf("Shell() error: %v", err)
 	}
 
@@ -96,10 +97,40 @@ func TestShell_FindsContainerAndExecsWithTTY(t *testing.T) {
 	}
 }
 
+func TestShell_PropagatesUser(t *testing.T) {
+	svc, runner := newTestContainer(t)
+
+	if err := svc.Shell("myapp", "devcontainer", []string{"zsh"}, "dev"); err != nil {
+		t.Fatalf("Shell() error: %v", err)
+	}
+
+	if len(runner.execCalls) != 1 {
+		t.Fatalf("expected 1 Exec call, got %d", len(runner.execCalls))
+	}
+	if got := runner.execCalls[0].user; got != "dev" {
+		t.Errorf("Exec user = %q, want %q", got, "dev")
+	}
+}
+
+func TestExec_PropagatesUser(t *testing.T) {
+	svc, runner := newTestContainer(t)
+
+	if err := svc.Exec("myapp", "devcontainer", []string{"true"}, "root"); err != nil {
+		t.Fatalf("Exec() error: %v", err)
+	}
+
+	if len(runner.execCalls) != 1 {
+		t.Fatalf("expected 1 Exec call, got %d", len(runner.execCalls))
+	}
+	if got := runner.execCalls[0].user; got != "root" {
+		t.Errorf("Exec user = %q, want %q", got, "root")
+	}
+}
+
 func TestShell_CustomCommand(t *testing.T) {
 	svc, runner := newTestContainer(t)
 
-	if err := svc.Shell("myapp", "devcontainer", []string{"bash", "-l"}); err != nil {
+	if err := svc.Shell("myapp", "devcontainer", []string{"bash", "-l"}, ""); err != nil {
 		t.Fatalf("Shell() error: %v", err)
 	}
 
@@ -116,7 +147,7 @@ func TestExec_FindsContainerAndExecsWithoutTTY(t *testing.T) {
 	svc, runner := newTestContainer(t)
 
 	cmd := []string{"go", "test", "./..."}
-	if err := svc.Exec("myapp", "devcontainer", cmd); err != nil {
+	if err := svc.Exec("myapp", "devcontainer", cmd, ""); err != nil {
 		t.Fatalf("Exec() error: %v", err)
 	}
 
@@ -187,7 +218,7 @@ func TestShell_ContainerNotFound(t *testing.T) {
 	runner.findResult = ""
 	runner.findErr = errors.New("container not found for project \"myapp\" service \"devcontainer\"")
 
-	err := svc.Shell("myapp", "devcontainer", []string{"zsh"})
+	err := svc.Shell("myapp", "devcontainer", []string{"zsh"}, "")
 	if err == nil {
 		t.Fatal("expected error when container not found")
 	}
@@ -206,7 +237,7 @@ func TestExec_ContainerNotFound(t *testing.T) {
 	runner.findResult = ""
 	runner.findErr = errors.New("container not found")
 
-	err := svc.Exec("myapp", "devcontainer", []string{"go", "test"})
+	err := svc.Exec("myapp", "devcontainer", []string{"go", "test"}, "")
 	if err == nil {
 		t.Fatal("expected error when container not found")
 	}
@@ -238,7 +269,7 @@ func TestShell_ExecFails(t *testing.T) {
 	svc, runner := newTestContainer(t)
 	runner.execErr = errors.New("exec failed")
 
-	err := svc.Shell("myapp", "devcontainer", []string{"zsh"})
+	err := svc.Shell("myapp", "devcontainer", []string{"zsh"}, "")
 	if err == nil {
 		t.Fatal("expected error when exec fails")
 	}
@@ -251,7 +282,7 @@ func TestExec_ExecFails(t *testing.T) {
 	svc, runner := newTestContainer(t)
 	runner.execErr = errors.New("exec failed")
 
-	err := svc.Exec("myapp", "devcontainer", []string{"go", "test"})
+	err := svc.Exec("myapp", "devcontainer", []string{"go", "test"}, "")
 	if err == nil {
 		t.Fatal("expected error when exec fails")
 	}

--- a/internal/service/template.go
+++ b/internal/service/template.go
@@ -94,7 +94,12 @@ type templateData struct {
 	CompanionVolumes []CompanionVolumeEntry
 	NetworkName      string // External network name (empty if not configured)
 	NetworkIP        string // Static IP on the external network
+	Command          string // Devcontainer command (never empty at render time)
 }
+
+// defaultCommand is the devcontainer command used when a template's
+// metadata.yaml does not set one.
+const defaultCommand = "sleep infinity"
 
 // TemplateService renders project templates into Dockerfile and compose content.
 type TemplateService struct {
@@ -175,6 +180,11 @@ func buildTemplateData(project domain.Project, meta *domain.TemplateMeta, mounts
 		return templateData{}, err
 	}
 
+	command := defaultCommand
+	if meta != nil && meta.Command != "" {
+		command = meta.Command
+	}
+
 	return templateData{
 		Project:          project,
 		ExposedPorts:     exposed,
@@ -184,6 +194,7 @@ func buildTemplateData(project domain.Project, meta *domain.TemplateMeta, mounts
 		NamedVolumes:     namedVolumes,
 		Companions:       companions,
 		CompanionVolumes: companionVolumes,
+		Command:          command,
 	}, nil
 }
 

--- a/internal/service/template_test.go
+++ b/internal/service/template_test.go
@@ -931,7 +931,7 @@ func TestRender_WithNetworkAndCompanions(t *testing.T) {
 func TestRender_DefaultsCommandToSleepInfinity(t *testing.T) {
 	src := &fakeSource{
 		dockerfile: "FROM ubuntu",
-		compose:    "services:\n  devcontainer:\n    command: {{ .Command }}\n",
+		compose:    "services:\n  devcontainer:\n    command: {{ printf \"%q\" .Command }}\n",
 		meta:       &domain.TemplateMeta{Name: "base"},
 	}
 	svc := service.NewTemplateService(src, nil)
@@ -940,15 +940,15 @@ func TestRender_DefaultsCommandToSleepInfinity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Render() error: %v", err)
 	}
-	if !strings.Contains(out.Compose, "command: sleep infinity") {
-		t.Errorf("expected default 'sleep infinity' command in compose, got:\n%s", out.Compose)
+	if !strings.Contains(out.Compose, `command: "sleep infinity"`) {
+		t.Errorf("expected default 'sleep infinity' command (quoted) in compose, got:\n%s", out.Compose)
 	}
 }
 
 func TestRender_UsesMetadataCommand(t *testing.T) {
 	src := &fakeSource{
 		dockerfile: "FROM ubuntu",
-		compose:    "services:\n  devcontainer:\n    command: {{ .Command }}\n",
+		compose:    "services:\n  devcontainer:\n    command: {{ printf \"%q\" .Command }}\n",
 		meta:       &domain.TemplateMeta{Name: "general", Command: "/usr/sbin/sshd -D -e"},
 	}
 	svc := service.NewTemplateService(src, nil)
@@ -957,11 +957,31 @@ func TestRender_UsesMetadataCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Render() error: %v", err)
 	}
-	if !strings.Contains(out.Compose, "command: /usr/sbin/sshd -D -e") {
-		t.Errorf("expected metadata-provided command in compose, got:\n%s", out.Compose)
+	if !strings.Contains(out.Compose, `command: "/usr/sbin/sshd -D -e"`) {
+		t.Errorf("expected metadata-provided command (quoted) in compose, got:\n%s", out.Compose)
 	}
 	if strings.Contains(out.Compose, "sleep infinity") {
 		t.Errorf("metadata command should override default; compose contains default:\n%s", out.Compose)
+	}
+}
+
+func TestRender_QuotesCommandWithYAMLMetachars(t *testing.T) {
+	// Verify that command values containing YAML-significant characters
+	// (hash comments, colons) are quoted so they survive YAML round-trip.
+	src := &fakeSource{
+		dockerfile: "FROM ubuntu",
+		compose:    "services:\n  devcontainer:\n    command: {{ printf \"%q\" .Command }}\n",
+		meta:       &domain.TemplateMeta{Name: "weird", Command: "bash -lc 'echo key: value # noted'"},
+	}
+	svc := service.NewTemplateService(src, nil)
+
+	out, err := svc.Render(domain.Project{Name: "myapp", Template: "weird"}, domain.Mounts{})
+	if err != nil {
+		t.Fatalf("Render() error: %v", err)
+	}
+	// After the %q escape, the value is a valid double-quoted YAML string.
+	if !strings.Contains(out.Compose, `command: "bash -lc 'echo key: value # noted'"`) {
+		t.Errorf("expected command to be YAML-quoted with metachars preserved, got:\n%s", out.Compose)
 	}
 }
 

--- a/internal/service/template_test.go
+++ b/internal/service/template_test.go
@@ -928,6 +928,43 @@ func TestRender_WithNetworkAndCompanions(t *testing.T) {
 	}
 }
 
+func TestRender_DefaultsCommandToSleepInfinity(t *testing.T) {
+	src := &fakeSource{
+		dockerfile: "FROM ubuntu",
+		compose:    "services:\n  devcontainer:\n    command: {{ .Command }}\n",
+		meta:       &domain.TemplateMeta{Name: "base"},
+	}
+	svc := service.NewTemplateService(src, nil)
+
+	out, err := svc.Render(domain.Project{Name: "myapp", Template: "base"}, domain.Mounts{})
+	if err != nil {
+		t.Fatalf("Render() error: %v", err)
+	}
+	if !strings.Contains(out.Compose, "command: sleep infinity") {
+		t.Errorf("expected default 'sleep infinity' command in compose, got:\n%s", out.Compose)
+	}
+}
+
+func TestRender_UsesMetadataCommand(t *testing.T) {
+	src := &fakeSource{
+		dockerfile: "FROM ubuntu",
+		compose:    "services:\n  devcontainer:\n    command: {{ .Command }}\n",
+		meta:       &domain.TemplateMeta{Name: "general", Command: "/usr/sbin/sshd -D -e"},
+	}
+	svc := service.NewTemplateService(src, nil)
+
+	out, err := svc.Render(domain.Project{Name: "myapp", Template: "general"}, domain.Mounts{})
+	if err != nil {
+		t.Fatalf("Render() error: %v", err)
+	}
+	if !strings.Contains(out.Compose, "command: /usr/sbin/sshd -D -e") {
+		t.Errorf("expected metadata-provided command in compose, got:\n%s", out.Compose)
+	}
+	if strings.Contains(out.Compose, "sleep infinity") {
+		t.Errorf("metadata command should override default; compose contains default:\n%s", out.Compose)
+	}
+}
+
 func TestRender_NoNetwork(t *testing.T) {
 	svc := service.NewTemplateService(newFakeSource(), nil)
 

--- a/templates/compose.yaml.tmpl
+++ b/templates/compose.yaml.tmpl
@@ -34,7 +34,7 @@ services:
       {{ .NetworkName }}:
         ipv4_address: {{ .NetworkIP }}
 {{- end }}
-    command: {{ .Command }}
+    command: {{ printf "%q" .Command }}
 {{- range .Companions }}
 
   {{ .Name }}:

--- a/templates/compose.yaml.tmpl
+++ b/templates/compose.yaml.tmpl
@@ -34,7 +34,7 @@ services:
       {{ .NetworkName }}:
         ipv4_address: {{ .NetworkIP }}
 {{- end }}
-    command: sleep infinity
+    command: {{ .Command }}
 {{- range .Companions }}
 
   {{ .Name }}:


### PR DESCRIPTION
## Summary
- Adds two optional top-level fields to `metadata.yaml`: `command` (devcontainer long-running command, defaults to `sleep infinity`) and `exec_user` (user for `deckhand shell` / `exec`).
- Templates that run a daemon (e.g. sshd) can now declare it declaratively without overriding the shared `compose.yaml.tmpl`.
- `exec_user` decouples the interactive-session user from the Dockerfile `USER` directive — needed whenever the container must start as root but shells should land as a non-root user.
- `base` and `python` set neither field → identical rendered output to today.

Motivated by a forthcoming `general` template (private `deckhand-templates` repo) whose whole purpose is running sshd on :22 for direct Tailscale-routed SSH. Full design: [`design/specs/2026-04-19-template-metadata-command-exec-user-design.md`](design/specs/2026-04-19-template-metadata-command-exec-user-design.md).

## Layers touched
- `internal/domain/project.go` — `TemplateMeta.Command`, `TemplateMeta.ExecUser`
- `internal/service/template.go` — `templateData.Command`; `defaultCommand = "sleep infinity"` applied at render time
- `internal/service/container.go` — `ContainerRunner.Exec` and `ContainerService.Shell`/`Exec` gain a `user` parameter
- `internal/infra/docker/container.go` — `Container.Exec` sets `ExecCreateOptions.User` when non-empty
- `internal/cli/{shell,exec}.go` + `helpers.go` — load template metadata and pass `ExecUser` through
- `templates/compose.yaml.tmpl` — `command: sleep infinity` → `command: {{ .Command }}`
- `docs/custom-templates.md` — documents both fields and adds a daemon-template section

## Test plan
- [x] `go build ./...`
- [x] `go test -short ./...` — all pass, including new parser/render/propagation assertions
- [x] `golangci-lint run ./...` — 0 issues
- [ ] Integration: build image from a template that sets `command` + `exec_user`, verify sshd starts and `deckhand shell` lands in the declared user (follow-up in the `deckhand-templates` repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `command` field in template metadata to override the devcontainer's default long-running command.
  * Added optional `exec_user` field in template metadata to specify the user for `deckhand shell` and `deckhand exec` operations.
  * Both fields support running long-lived daemons without custom compose templates.

* **Documentation**
  * Updated custom templates documentation with examples of using the new metadata fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->