### PR TITLE
feat: add one-liner install script for Linux binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,13 @@ jobs:
             -o deckhand-${{ matrix.goos }}-${{ matrix.goarch }} \
             ./cmd/deckhand
 
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Run shellcheck on install.sh
+        run: shellcheck install.sh
+
   version:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ coverage.out
 # Claude Code hook debug logs
 .claude/hooks/hook-debug.log
 
+# Claude Code scheduled tasks runtime lock
+.claude/scheduled_tasks.lock
+
 # IDE
 .idea/
 .vscode/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Deckhand manages the full lifecycle of containerized dev environments — from s
 ### One-liner install (Linux amd64/arm64)
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/TomasGrbalik/Deckhand/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/TomasGrbalik/Deckhand/main/install.sh | sh
 ```
 
 This detects your architecture, downloads the latest release tarball and its `checksums.txt`, verifies the SHA256, and installs the binary to `/usr/local/bin/deckhand`.
@@ -17,7 +17,7 @@ This detects your architecture, downloads the latest release tarball and its `ch
 Pin a specific version:
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/TomasGrbalik/Deckhand/main/install.sh | VERSION=v0.2.0 sh
+curl -fsSL https://raw.githubusercontent.com/TomasGrbalik/Deckhand/main/install.sh | VERSION=v0.2.0 sh
 ```
 
 ### Binary download (manual)

--- a/README.md
+++ b/README.md
@@ -6,9 +6,23 @@ Deckhand manages the full lifecycle of containerized dev environments — from s
 
 ## Install
 
-### Binary download (GitHub Releases)
+### One-liner install (Linux amd64/arm64)
 
-Download the latest release for your platform:
+```bash
+curl -sSL https://raw.githubusercontent.com/TomasGrbalik/Deckhand/main/install.sh | sh
+```
+
+This detects your architecture, downloads the latest release tarball and its `checksums.txt`, verifies the SHA256, and installs the binary to `/usr/local/bin/deckhand`.
+
+Pin a specific version:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/TomasGrbalik/Deckhand/main/install.sh | VERSION=v0.2.0 sh
+```
+
+### Binary download (manual)
+
+If you prefer to download manually:
 
 ```bash
 # Linux amd64
@@ -17,16 +31,9 @@ curl -Lo deckhand.tar.gz "https://github.com/TomasGrbalik/Deckhand/releases/late
 tar xzf deckhand.tar.gz deckhand
 sudo mv deckhand /usr/local/bin/
 rm deckhand.tar.gz
-
-# Linux arm64
-VERSION=$(curl -sL https://api.github.com/repos/TomasGrbalik/Deckhand/releases/latest | grep '"tag_name"' | cut -d'"' -f4 | sed 's/^v//')
-curl -Lo deckhand.tar.gz "https://github.com/TomasGrbalik/Deckhand/releases/latest/download/deckhand_${VERSION}_linux_arm64.tar.gz"
-tar xzf deckhand.tar.gz deckhand
-sudo mv deckhand /usr/local/bin/
-rm deckhand.tar.gz
 ```
 
-Each release includes a `checksums.txt` file for verification.
+Each release includes a `checksums.txt` file for verification. For arm64, replace `amd64` with `arm64`.
 
 ### go install
 

--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,8 @@
 # Deckhand install script.
 #
 # Usage:
-#   curl -sSL https://raw.githubusercontent.com/TomasGrbalik/Deckhand/main/install.sh | sh
-#   curl -sSL https://raw.githubusercontent.com/TomasGrbalik/Deckhand/main/install.sh | VERSION=v0.2.0 sh
+#   curl -fsSL https://raw.githubusercontent.com/TomasGrbalik/Deckhand/main/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/TomasGrbalik/Deckhand/main/install.sh | VERSION=v0.2.0 sh
 
 set -eu
 
@@ -24,13 +24,14 @@ need_cmd() {
 	command -v "$1" >/dev/null 2>&1 || err "required command not found: $1"
 }
 
-need_cmd curl
-need_cmd tar
-need_cmd sha256sum
 need_cmd uname
 
 OS=$(uname -s)
 [ "$OS" = "Linux" ] || err "unsupported OS: $OS (only Linux is supported; use 'go install' for other platforms)"
+
+need_cmd curl
+need_cmd tar
+need_cmd sha256sum
 
 RAW_ARCH=$(uname -m)
 case "$RAW_ARCH" in
@@ -77,14 +78,14 @@ info "Extracting..."
 tar -xzf "${TMP}/${TARBALL}" -C "$TMP" deckhand
 
 TARGET="${INSTALL_DIR}/deckhand"
-if [ -w "$INSTALL_DIR" ] || ([ ! -e "$INSTALL_DIR" ] && mkdir -p "$INSTALL_DIR" 2>/dev/null); then
-	mv "${TMP}/deckhand" "$TARGET"
-	chmod +x "$TARGET"
+need_cmd install
+if [ -w "$INSTALL_DIR" ] || { [ ! -e "$INSTALL_DIR" ] && mkdir -p "$INSTALL_DIR" 2>/dev/null; }; then
+	install -m 0755 "${TMP}/deckhand" "$TARGET"
 else
 	info "Installing to ${TARGET} (requires sudo)..."
 	need_cmd sudo
-	sudo mv "${TMP}/deckhand" "$TARGET"
-	sudo chmod +x "$TARGET"
+	sudo install -d "$INSTALL_DIR"
+	sudo install -m 0755 -o root -g root "${TMP}/deckhand" "$TARGET"
 fi
 
 info "Installed: $("$TARGET" --version 2>/dev/null || printf 'deckhand %s' "$VERSION")"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+# Deckhand install script.
+#
+# Usage:
+#   curl -sSL https://raw.githubusercontent.com/TomasGrbalik/Deckhand/main/install.sh | sh
+#   curl -sSL https://raw.githubusercontent.com/TomasGrbalik/Deckhand/main/install.sh | VERSION=v0.2.0 sh
+
+set -eu
+
+REPO="TomasGrbalik/Deckhand"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+VERSION="${VERSION:-}"
+
+err() {
+	printf 'error: %s\n' "$1" >&2
+	exit 1
+}
+
+info() {
+	printf '%s\n' "$1"
+}
+
+need_cmd() {
+	command -v "$1" >/dev/null 2>&1 || err "required command not found: $1"
+}
+
+need_cmd curl
+need_cmd tar
+need_cmd sha256sum
+need_cmd uname
+
+OS=$(uname -s)
+[ "$OS" = "Linux" ] || err "unsupported OS: $OS (only Linux is supported; use 'go install' for other platforms)"
+
+RAW_ARCH=$(uname -m)
+case "$RAW_ARCH" in
+	x86_64|amd64) ARCH="amd64" ;;
+	aarch64|arm64) ARCH="arm64" ;;
+	*) err "unsupported architecture: $RAW_ARCH (use 'go install github.com/TomasGrbalik/Deckhand/cmd/deckhand@latest' or download manually)" ;;
+esac
+
+if [ -z "$VERSION" ]; then
+	info "Resolving latest release..."
+	VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+		| grep '"tag_name"' \
+		| head -n 1 \
+		| cut -d'"' -f4)
+	[ -n "$VERSION" ] || err "failed to resolve latest version"
+fi
+
+# Strip leading 'v' for artifact filenames (GoReleaser names files without 'v').
+VERSION_NUM="${VERSION#v}"
+TARBALL="deckhand_${VERSION_NUM}_linux_${ARCH}.tar.gz"
+BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
+
+TMP=$(mktemp -d 2>/dev/null || mktemp -d -t deckhand)
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+info "Downloading ${TARBALL}..."
+curl -fsSL -o "${TMP}/${TARBALL}" "${BASE_URL}/${TARBALL}" \
+	|| err "failed to download ${TARBALL} (is ${VERSION} a valid release?)"
+
+info "Downloading checksums.txt..."
+curl -fsSL -o "${TMP}/checksums.txt" "${BASE_URL}/checksums.txt" \
+	|| err "failed to download checksums.txt"
+
+info "Verifying SHA256..."
+(
+	cd "$TMP"
+	grep " ${TARBALL}\$" checksums.txt > checksum.expected \
+		|| { printf 'error: no checksum entry for %s\n' "$TARBALL" >&2; exit 1; }
+	sha256sum -c checksum.expected >/dev/null \
+		|| { printf 'error: checksum mismatch for %s\n' "$TARBALL" >&2; exit 1; }
+)
+
+info "Extracting..."
+tar -xzf "${TMP}/${TARBALL}" -C "$TMP" deckhand
+
+TARGET="${INSTALL_DIR}/deckhand"
+if [ -w "$INSTALL_DIR" ] || ([ ! -e "$INSTALL_DIR" ] && mkdir -p "$INSTALL_DIR" 2>/dev/null); then
+	mv "${TMP}/deckhand" "$TARGET"
+	chmod +x "$TARGET"
+else
+	info "Installing to ${TARGET} (requires sudo)..."
+	need_cmd sudo
+	sudo mv "${TMP}/deckhand" "$TARGET"
+	sudo chmod +x "$TARGET"
+fi
+
+info "Installed: $("$TARGET" --version 2>/dev/null || printf 'deckhand %s' "$VERSION")"
+info "Location:  $TARGET"


### PR DESCRIPTION
## Summary
- New `install.sh` at repo root: arch detection, SHA256 verification against `checksums.txt`, optional `VERSION=` pin, sudo only when needed.
- Shellcheck CI job for the script.
- README leads with the one-liner; manual download remains as fallback.

Closes #84

## Test plan
- [ ] CI shellcheck job passes
- [ ] Run the one-liner on a Linux amd64 host after next release and confirm the binary installs and reports the expected version
- [ ] Run with `VERSION=v0.2.0` and confirm the pinned version installs
- [ ] Tamper with the downloaded tarball (manually) and confirm the script aborts on checksum mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simplified one-liner installation method for Linux with automatic latest release detection.
  * Support for version pinning via environment variables during installation.
  * Automatic architecture detection (amd64/arm64) and built-in checksum verification.

* **Documentation**
  * Updated installation guide with new script-based installation approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->