### PR TITLE
feat(template): auto-restart containers after host reboot

### DIFF
--- a/templates/compose.yaml.tmpl
+++ b/templates/compose.yaml.tmpl
@@ -35,6 +35,7 @@ services:
         ipv4_address: {{ .NetworkIP }}
 {{- end }}
     command: {{ printf "%q" .Command }}
+    restart: unless-stopped
 {{- range .Companions }}
 
   {{ .Name }}:
@@ -43,6 +44,7 @@ services:
       dev.deckhand.managed: "true"
       dev.deckhand.project: "{{ $.Name }}"
       dev.deckhand.service: "{{ .Name }}"
+    restart: unless-stopped
 {{- if .Ports }}
     ports:
 {{- range .Ports }}


### PR DESCRIPTION
## Summary
- Add `restart: unless-stopped` to both the devcontainer and every companion service in the generated compose file
- Containers now come back automatically when the Docker daemon restarts (host reboot / `systemctl restart docker`), so users no longer have to SSH in and run `deckhand up` per project
- Manual stops (`deckhand down` / `deckhand stop`) are still honored — `unless-stopped` only triggers on daemon-initiated restarts

## Why hardcode it
The only sensible value for a dev environment is `unless-stopped`: `no` defeats the purpose, `always` fights `deckhand down`, and `on-failure` doesn't cover reboots. Exposing a knob would add domain/config/validation plumbing for a choice no one would realistically make differently. Easy to lift into `.deckhand.yaml` later if a real use case appears.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [ ] On a real host: `deckhand up`, then `sudo systemctl restart docker`, confirm devcontainer + companions come back up (`docker ps`)
- [ ] On a real host: `deckhand down`, then `sudo systemctl restart docker`, confirm containers stay down

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container restart policies to automatically restart services unless explicitly stopped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->